### PR TITLE
Switch from unittest -> pytest (#2)

### DIFF
--- a/tests/test_addressing_modes.py
+++ b/tests/test_addressing_modes.py
@@ -7,409 +7,404 @@ from emupy6502.registers import Registers
 from emupy6502.addressing_modes import AddressingModes
 
 
-class AdressingModesTests(unittest.TestCase):
-    
-    def test_implied_has_no_effect(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            # 'RTS' opcode is implied address mode
-            count = addressing_modes.handle(0x60, registers, mock_memory_controller)
-            self.assertEqual(count, None)
-            mock_memory_controller.assert_not_called()
-            self.assertTrue(registers == Registers())
-
-    def test_immediate_loads_next_value_from_pc(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            mock_memory_controller.read.return_value = 0x22
-            # 'LDA' 0xA9 opcode is immediate address mode
-            value = addressing_modes.handle(0xA9, registers, mock_memory_controller)
-            mock_memory_controller.read.assert_called_with(0)
-            self.assertEqual(registers.pc, 1)
-            self.assertEqual(value, 0x22)
-
-    def test_relative_loads_next_value_from_pc(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            mock_memory_controller.read.return_value = 0x22
-            # 'BPL' 0x10 opcode is relative address mode
-            value = addressing_modes.handle(0x10, registers, mock_memory_controller)
-            mock_memory_controller.read.assert_called_with(0)
-            self.assertEqual(registers.pc, 1)
-            self.assertEqual(value, 0x22)
-
-    def test_zero_page_calls_read_correctly(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xa5 0x22 and value at [0x0022] = 1
-            mock_memory_controller.read.side_effect = [0x22, 1]
-            # 'LDA' 0xA5 opcode is zero page address mode
-            value = addressing_modes.handle(0xA5, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x22))
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 1)
-
-    def test_absolute_jmp_calls_read_correctly(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xa5 0x22 and value at [0x0022] = 1
-            mock_memory_controller.read.side_effect = [0x22, 0x23, 1]
-            # 'JMP' 0x4c opcode is absolute address mode
-            value = addressing_modes.handle(0x4C, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(2))
-            self.assertEqual(registers.pc, 3)
-            self.assertEqual(value, 0x2322)
-
-    def test_absolute_calls_read_correctly(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xa5 0x22 and value at [0x0022] = 1
-            mock_memory_controller.read.side_effect = [0x22, 0x23, 1]
-            # 'LDA' 0xad opcode is absolute address mode
-            value = addressing_modes.handle(0xAD, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 3)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(2))
-            self.assertEqual(mock_memory_controller.read.call_args_list[2], unittest.mock.call(0x2322))
-            self.assertEqual(registers.pc, 3)
-            self.assertEqual(value, 1)
-
-    def test_zero_page_x_index_calls_read_correctly(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.x_index = 3
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xB5 0x03 and value at [0x06] = 1
-            mock_memory_controller.read.side_effect = [3, 1]
-            # 'LDA' 0xB5 opcode is zero page x indexed address mode
-            value = addressing_modes.handle(0xB5, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(6))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 1)
-
-    def test_zero_page_x_index_deals_with_wraparound(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.x_index = 0xff
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xB5 0x03 and value at [0x02] = 1
-            mock_memory_controller.read.side_effect = [3, 1]
-            # 'LDA' 0xB5 opcode is zero page x indexed address mode
-            value = addressing_modes.handle(0xB5, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(2))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 1)
-
-    def test_zero_page_y_index_calls_read_correctly(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.y_index = 3
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xB6 0x03 and value at [0x06] = 1
-            mock_memory_controller.read.side_effect = [3, 1]
-            # 'LDX' 0xB6 opcode is zero page x indexed address mode
-            value = addressing_modes.handle(0xB6, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(6))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 1)
-
-    def test_zero_page_y_index_deals_with_wraparound(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.y_index = 0xff
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xB6 0x03 and value at [0x02] = 1
-            mock_memory_controller.read.side_effect = [3, 1]
-            # 'LDX 0xB6 opcode is zero page x indexed address mode
-            value = addressing_modes.handle(0xB6, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(2))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 1)
-
-    def test_indirect(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.y_index = 0xff
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0x6C 0x03 0xf0 and value at [0xf003] = 0x1234
-            mock_memory_controller.read.side_effect = [3, 0xf0, 0x34, 0x12]
-            # 'JMP' 0x6C opcode uses indirect addressing
-            value = addressing_modes.handle(0x6C, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 4)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(2))
-            self.assertEqual(mock_memory_controller.read.call_args_list[2], unittest.mock.call(0xf003))
-            self.assertEqual(mock_memory_controller.read.call_args_list[3], unittest.mock.call(0xf004))
-            self.assertEqual(registers.pc, 3)
-            self.assertEqual(value, 0x1234)
-
-    def test_zp_index_indirect_x(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.x_index = 0x3
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xA1 0x03 and value at [0x06] = 0x1234
-            mock_memory_controller.read.side_effect = [3, 0x34, 0x12]
-            # 'LDA' 0xA1 opcode uses indirect addressing
-            value = addressing_modes.handle(0xA1, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 3)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(6))
-            self.assertEqual(mock_memory_controller.read.call_args_list[2], unittest.mock.call(7))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 0x1234)
-
-    def test_zp_index_indirect_x_wraparound_1(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.x_index = 0xff
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xA1 0x03 and value at [0xff] = 0x12, [0x00] = 0x34
-            mock_memory_controller.read.side_effect = [3, 0x34, 0x12]
-            # 'LDA' 0xA1 opcode uses indirect addressing
-            value = addressing_modes.handle(0xA1, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 3)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(2))
-            self.assertEqual(mock_memory_controller.read.call_args_list[2], unittest.mock.call(3))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 0x1234)
-
-    def test_zp_index_indirect_x_wraparound_2(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.x_index = 0xfe
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xA1 0x03 and value at [0xff] = 0x12, [0x00] = 0x34
-            mock_memory_controller.read.side_effect = [1, 0x34, 0x12]
-            # 'LDA' 0xA1 opcode uses indirect addressing
-            value = addressing_modes.handle(0xA1, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 3)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0xff))
-            self.assertEqual(mock_memory_controller.read.call_args_list[2], unittest.mock.call(0))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 0x1234)
-
-    def test_absolute_x(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.x_index = 0x3
-        AddressingModes.cycle_count = 0
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xBD 0xc000 
-            mock_memory_controller.read.side_effect = [0, 0xc0]
-            # 'LDA' 0xBD opcode uses indirect addressing
-            value = addressing_modes.handle(0xBD, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(2))
-            self.assertEqual(registers.pc, 3)
-            self.assertEqual(value, 0xc003)
-            self.assertEqual(AddressingModes.cycle_count, 0)
-
-    def test_absolute_x_page_boundary(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.x_index = 0x3
-        AddressingModes.cycle_count = 0
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xBD 0xc000 
-            mock_memory_controller.read.side_effect = [0xfe, 0xc0]
-            # 'LDA' 0xBD opcode uses indirect addressing
-            value = addressing_modes.handle(0xBD, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(2))
-            self.assertEqual(registers.pc, 3)
-            self.assertEqual(value, 0xc101)
-            self.assertEqual(AddressingModes.cycle_count, 1)
-
-    def test_absolute_y(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.y_index = 0x3
-        AddressingModes.cycle_count = 0
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xB9 0xc000 
-            mock_memory_controller.read.side_effect = [0, 0xc0]
-            # 'LDA' 0xB9 opcode uses indirect addressing
-            value = addressing_modes.handle(0xB9, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(2))
-            self.assertEqual(registers.pc, 3)
-            self.assertEqual(value, 0xc003)
-            self.assertEqual(AddressingModes.cycle_count, 0)
-
-    def test_absolute_y_page_boundary(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.y_index = 0x3
-        AddressingModes.cycle_count = 0
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xB9 0xc000 
-            mock_memory_controller.read.side_effect = [0xfe, 0xc0]
-            # 'LDA' 0xB9 opcode uses indirect addressing
-            value = addressing_modes.handle(0xB9, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(2))
-            self.assertEqual(registers.pc, 3)
-            self.assertEqual(value, 0xc101)
-            self.assertEqual(AddressingModes.cycle_count, 1)
-
-    def test_indirect_indexed_y(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.y_index = 0x3
-        AddressingModes.cycle_count = 0
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xB1 0x2a  memory at 0x2a = [0x28, 0x40]
-            mock_memory_controller.read.side_effect = [0x2a, 0x28, 0x40]
-            # 'LDA' 0xB9 opcode uses indirect addressing
-            value = addressing_modes.handle(0xB1, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 3)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x2a))
-            self.assertEqual(mock_memory_controller.read.call_args_list[2], unittest.mock.call(0x2b))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 0x402b)
-            self.assertEqual(AddressingModes.cycle_count, 0)
-
-    def test_indirect_indexed_y_zp_boundary(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.y_index = 0x3
-        AddressingModes.cycle_count = 0
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xB1 0xff  memory at 0xff = [0x28, 0x40]
-            mock_memory_controller.read.side_effect = [0xff, 0x28, 0x40]
-            # 'LDA' 0xB9 opcode uses indirect addressing
-            value = addressing_modes.handle(0xB1, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 3)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0xff))
-            self.assertEqual(mock_memory_controller.read.call_args_list[2], unittest.mock.call(0x00))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 0x402b)
-            self.assertEqual(AddressingModes.cycle_count, 0)
-
-    def test_indirect_indexed_y_page_boundary(self):
-
-        addressing_modes = AddressingModes()
-        registers = Registers()
-        registers.pc = 1 #fake loading of opcode
-        registers.y_index = 0x3
-        AddressingModes.cycle_count = 0
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xB1 0x2a  memory at 0x2a = [0xfe, 0x40]
-            mock_memory_controller.read.side_effect = [0x2a, 0xfe, 0x40]
-            # 'LDA' 0xB9 opcode uses indirect addressing
-            value = addressing_modes.handle(0xB1, registers, mock_memory_controller)
-            self.assertEqual(mock_memory_controller.read.call_count, 3)
-            self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-            self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x2a))
-            self.assertEqual(mock_memory_controller.read.call_args_list[2], unittest.mock.call(0x2b))
-            self.assertEqual(registers.pc, 2)
-            self.assertEqual(value, 0x4101)
-            self.assertEqual(AddressingModes.cycle_count, 1)
-
-if __name__ == '__main__':
-    unittest.main()
+def test_implied_has_no_effect():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        # 'RTS' opcode is implied address mode
+        count = addressing_modes.handle(0x60, registers, mock_memory_controller)
+        assert count == None
+        mock_memory_controller.assert_not_called()
+        assert registers == Registers()
+
+def test_immediate_loads_next_value_from_pc():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        mock_memory_controller.read.return_value = 0x22
+        # 'LDA' 0xA9 opcode is immediate address mode
+        value = addressing_modes.handle(0xA9, registers, mock_memory_controller)
+        mock_memory_controller.read.assert_called_with(0)
+        assert registers.pc == 1
+        assert value == 0x22
+
+def test_relative_loads_next_value_from_pc():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        mock_memory_controller.read.return_value = 0x22
+        # 'BPL' 0x10 opcode is relative address mode
+        value = addressing_modes.handle(0x10, registers, mock_memory_controller)
+        mock_memory_controller.read.assert_called_with(0)
+        assert registers.pc == 1
+        assert value == 0x22
+
+def test_zero_page_calls_read_correctly():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xa5 0x22 and value at [0x0022] = 1
+        mock_memory_controller.read.side_effect = [0x22, 1]
+        # 'LDA' 0xA5 opcode is zero page address mode
+        value = addressing_modes.handle(0xA5, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 2
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x22)
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert registers.pc == 2
+        assert value == 1
+
+def test_absolute_jmp_calls_read_correctly():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xa5 0x22 and value at [0x0022] = 1
+        mock_memory_controller.read.side_effect = [0x22, 0x23, 1]
+        # 'JMP' 0x4c opcode is absolute address mode
+        value = addressing_modes.handle(0x4C, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 2
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(2)
+        assert registers.pc == 3
+        assert value == 0x2322
+
+def test_absolute_calls_read_correctly():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xa5 0x22 and value at [0x0022] = 1
+        mock_memory_controller.read.side_effect = [0x22, 0x23, 1]
+        # 'LDA' 0xad opcode is absolute address mode
+        value = addressing_modes.handle(0xAD, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 3
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(2)
+        assert mock_memory_controller.read.call_args_list[2] == unittest.mock.call(0x2322)
+        assert registers.pc == 3
+        assert value == 1
+
+def test_zero_page_x_index_calls_read_correctly():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.x_index = 3
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xB5 0x03 and value at [0x06] = 1
+        mock_memory_controller.read.side_effect = [3, 1]
+        # 'LDA' 0xB5 opcode is zero page x indexed address mode
+        value = addressing_modes.handle(0xB5, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 2
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(6)
+        assert registers.pc == 2
+        assert value == 1
+
+def test_zero_page_x_index_deals_with_wraparound():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.x_index = 0xff
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xB5 0x03 and value at [0x02] = 1
+        mock_memory_controller.read.side_effect = [3, 1]
+        # 'LDA' 0xB5 opcode is zero page x indexed address mode
+        value = addressing_modes.handle(0xB5, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 2
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(2)
+        assert registers.pc == 2
+        assert value == 1
+
+def test_zero_page_y_index_calls_read_correctly():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.y_index = 3
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xB6 0x03 and value at [0x06] = 1
+        mock_memory_controller.read.side_effect = [3, 1]
+        # 'LDX' 0xB6 opcode is zero page x indexed address mode
+        value = addressing_modes.handle(0xB6, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 2
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(6)
+        assert registers.pc == 2
+        assert value == 1
+
+def test_zero_page_y_index_deals_with_wraparound():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.y_index = 0xff
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xB6 0x03 and value at [0x02] = 1
+        mock_memory_controller.read.side_effect = [3, 1]
+        # 'LDX 0xB6 opcode is zero page x indexed address mode
+        value = addressing_modes.handle(0xB6, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 2
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(2)
+        assert registers.pc == 2
+        assert value == 1
+
+def test_indirect():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.y_index = 0xff
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0x6C 0x03 0xf0 and value at [0xf003] = 0x1234
+        mock_memory_controller.read.side_effect = [3, 0xf0, 0x34, 0x12]
+        # 'JMP' 0x6C opcode uses indirect addressing
+        value = addressing_modes.handle(0x6C, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 4
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(2)
+        assert mock_memory_controller.read.call_args_list[2] == unittest.mock.call(0xf003)
+        assert mock_memory_controller.read.call_args_list[3] == unittest.mock.call(0xf004)
+        assert registers.pc == 3
+        assert value == 0x1234
+
+def test_zp_index_indirect_x():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.x_index = 0x3
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xA1 0x03 and value at [0x06] = 0x1234
+        mock_memory_controller.read.side_effect = [3, 0x34, 0x12]
+        # 'LDA' 0xA1 opcode uses indirect addressing
+        value = addressing_modes.handle(0xA1, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 3
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(6)
+        assert mock_memory_controller.read.call_args_list[2] == unittest.mock.call(7)
+        assert registers.pc == 2
+        assert value == 0x1234
+
+def test_zp_index_indirect_x_wraparound_1():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.x_index = 0xff
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xA1 0x03 and value at [0xff] = 0x12, [0x00] = 0x34
+        mock_memory_controller.read.side_effect = [3, 0x34, 0x12]
+        # 'LDA' 0xA1 opcode uses indirect addressing
+        value = addressing_modes.handle(0xA1, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 3
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(2)
+        assert mock_memory_controller.read.call_args_list[2] == unittest.mock.call(3)
+        assert registers.pc == 2
+        assert value == 0x1234
+
+def test_zp_index_indirect_x_wraparound_2():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.x_index = 0xfe
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xA1 0x03 and value at [0xff] = 0x12, [0x00] = 0x34
+        mock_memory_controller.read.side_effect = [1, 0x34, 0x12]
+        # 'LDA' 0xA1 opcode uses indirect addressing
+        value = addressing_modes.handle(0xA1, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 3
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0xff)
+        assert mock_memory_controller.read.call_args_list[2] == unittest.mock.call(0)
+        assert registers.pc == 2
+        assert value == 0x1234
+
+def test_absolute_x():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.x_index = 0x3
+    AddressingModes.cycle_count = 0
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xBD 0xc000 
+        mock_memory_controller.read.side_effect = [0, 0xc0]
+        # 'LDA' 0xBD opcode uses indirect addressing
+        value = addressing_modes.handle(0xBD, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 2
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(2)
+        assert registers.pc == 3
+        assert value == 0xc003
+        assert AddressingModes.cycle_count == 0
+
+def test_absolute_x_page_boundary():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.x_index = 0x3
+    AddressingModes.cycle_count = 0
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xBD 0xc000 
+        mock_memory_controller.read.side_effect = [0xfe, 0xc0]
+        # 'LDA' 0xBD opcode uses indirect addressing
+        value = addressing_modes.handle(0xBD, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 2
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(2)
+        assert registers.pc == 3
+        assert value == 0xc101
+        assert AddressingModes.cycle_count == 1
+
+def test_absolute_y():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.y_index = 0x3
+    AddressingModes.cycle_count = 0
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xB9 0xc000 
+        mock_memory_controller.read.side_effect = [0, 0xc0]
+        # 'LDA' 0xB9 opcode uses indirect addressing
+        value = addressing_modes.handle(0xB9, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 2
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(2)
+        assert registers.pc == 3
+        assert value == 0xc003
+        assert AddressingModes.cycle_count == 0
+
+def test_absolute_y_page_boundary():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.y_index = 0x3
+    AddressingModes.cycle_count = 0
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xB9 0xc000 
+        mock_memory_controller.read.side_effect = [0xfe, 0xc0]
+        # 'LDA' 0xB9 opcode uses indirect addressing
+        value = addressing_modes.handle(0xB9, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 2
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(2)
+        assert registers.pc == 3
+        assert value == 0xc101
+        assert AddressingModes.cycle_count == 1
+
+def test_indirect_indexed_y():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.y_index = 0x3
+    AddressingModes.cycle_count = 0
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xB1 0x2a  memory at 0x2a = [0x28, 0x40]
+        mock_memory_controller.read.side_effect = [0x2a, 0x28, 0x40]
+        # 'LDA' 0xB9 opcode uses indirect addressing
+        value = addressing_modes.handle(0xB1, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 3
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x2a)
+        assert mock_memory_controller.read.call_args_list[2] == unittest.mock.call(0x2b)
+        assert registers.pc == 2
+        assert value == 0x402b
+        assert AddressingModes.cycle_count == 0
+
+def test_indirect_indexed_y_zp_boundary():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.y_index = 0x3
+    AddressingModes.cycle_count = 0
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xB1 0xff  memory at 0xff = [0x28, 0x40]
+        mock_memory_controller.read.side_effect = [0xff, 0x28, 0x40]
+        # 'LDA' 0xB9 opcode uses indirect addressing
+        value = addressing_modes.handle(0xB1, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 3
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0xff)
+        assert mock_memory_controller.read.call_args_list[2] == unittest.mock.call(0x00)
+        assert registers.pc == 2
+        assert value == 0x402b
+        assert AddressingModes.cycle_count == 0
+
+def test_indirect_indexed_y_page_boundary():
+
+    addressing_modes = AddressingModes()
+    registers = Registers()
+    registers.pc = 1 #fake loading of opcode
+    registers.y_index = 0x3
+    AddressingModes.cycle_count = 0
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xB1 0x2a  memory at 0x2a = [0xfe, 0x40]
+        mock_memory_controller.read.side_effect = [0x2a, 0xfe, 0x40]
+        # 'LDA' 0xB9 opcode uses indirect addressing
+        value = addressing_modes.handle(0xB1, registers, mock_memory_controller)
+        assert mock_memory_controller.read.call_count == 3
+        assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+        assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x2a)
+        assert mock_memory_controller.read.call_args_list[2] == unittest.mock.call(0x2b)
+        assert registers.pc == 2
+        assert value == 0x4101
+        assert AddressingModes.cycle_count == 1

--- a/tests/test_arithmetic_opcodes.py
+++ b/tests/test_arithmetic_opcodes.py
@@ -6,548 +6,543 @@ from emupy6502.registers import Registers
 from emupy6502.opcodes import OpCode
 
 
-class OpCodeTestsArithmetic(unittest.TestCase):
-    
-    def execute_adc_carry_clear(self, actual_opcode, expected_clocks):
+def execute_adc_carry_clear( actual_opcode, expected_clocks):
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 5
-        registers.zero_flag = True
-        registers.negative_flag = True  
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 5
+    registers.zero_flag = True
+    registers.negative_flag = True  
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-            mock_memory_controller.read.return_value = 0x22
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(actual_opcode, registers, mock_memory_controller)
-            self.assertEqual(count, expected_clocks)
-            self.assertTrue(registers.accumulator == 0x27)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    def execute_adc_carry_set(self, actual_opcode, expected_clocks):
-
-        opcode = OpCode()
-        registers = Registers() 
-        registers.accumulator = 5
-        registers.zero_flag = True
-        registers.negative_flag = True  
-        registers.carry_flag = True  
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            mock_memory_controller.read.return_value = 0x22
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(actual_opcode, registers, mock_memory_controller)
-            self.assertEqual(count, expected_clocks)
-            self.assertTrue(registers.accumulator == 0x28)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    def execute_adc_should_set_carry(self, actual_opcode, expected_clocks):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 1
-        registers.zero_flag = False
-        registers.negative_flag = True    
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            mock_memory_controller.read.return_value = 0xff
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(actual_opcode, registers, mock_memory_controller)
-            self.assertEqual(count, expected_clocks)
-            self.assertTrue(registers.accumulator == 0)
-            self.assertTrue(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertTrue(registers.carry_flag)
-
-    def test_execute_adc_immediate_carry_clear(self):
-
-        self.execute_adc_carry_clear(0x69, 2)
-
-    def test_execute_adc_immediate_carry_set(self):
-
-        self.execute_adc_carry_set(0x69, 2)
-
-    def test_execute_adc_immediate_should_set_carry(self):
-
-        self.execute_adc_should_set_carry(0x69, 2)
-
-    def test_execute_adc_zeropage_carry_clear(self):
-
-        self.execute_adc_carry_clear(0x65, 3)
-
-    def test_execute_adc_zeropage_carry_set(self):
-
-        self.execute_adc_carry_set(0x65, 3)
-
-    def test_execute_adc_zeropage_should_set_carry(self):
-
-        self.execute_adc_should_set_carry(0x65, 3)
-
-    # No need to test all combinations of carry, uses same code as
-    # other immediate addressing modes
-    def test_execute_adc_immediate_zp_x(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 5
-        registers.x_index = 3
-        registers.zero_flag = True
-        registers.negative_flag = True  
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xb5 0x21 and value at [0x0024] = 1
-            mock_memory_controller.read.side_effect = [0x21, 1]
-
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x75, registers, mock_memory_controller)
-            self.assertEqual(count, 4)
-            self.assertTrue(registers.accumulator == 6)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    # No need to test all combinations of carry, uses same code as
-    # other immediate addressing modes
-    def test_execute_adc_absolute(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 5
-        registers.zero_flag = True
-        registers.negative_flag = True  
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xb5 0x21 0x22 and value at [0x2221] = 1
-            mock_memory_controller.read.side_effect = [0x21, 0x22, 1]
-
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x6D, registers, mock_memory_controller)
-            self.assertEqual(count, 4)
-            self.assertTrue(registers.accumulator == 6)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    def test_execute_adc_absolute_x(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 5
-        registers.x_index = 3
-        registers.zero_flag = True
-        registers.negative_flag = True  
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xBD 0x2100 and value at [0x2103] = 1
-            mock_memory_controller.read.side_effect = [0, 0x21, 1]
-
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x7D, registers, mock_memory_controller)
-            self.assertEqual(count, 4)
-            self.assertTrue(registers.accumulator == 6)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    def test_execute_adc_absolute_x_page_boundary(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 5
-        registers.x_index = 3
-        registers.zero_flag = True
-        registers.negative_flag = True  
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xBD 0x2100 and value at [0x2202] = 1
-            mock_memory_controller.read.side_effect = [0xff, 0x21, 1]
-
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x7D, registers, mock_memory_controller)
-            self.assertEqual(count, 5)
-            self.assertTrue(registers.accumulator == 6)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    def test_execute_adc_absolute_y(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 5
-        registers.y_index = 3
-        registers.zero_flag = True
-        registers.negative_flag = True  
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xBD 0x2100 and value at [0x2103] = 1
-            mock_memory_controller.read.side_effect = [0, 0x21, 1]
-
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x79, registers, mock_memory_controller)
-            self.assertEqual(count, 4)
-            self.assertTrue(registers.accumulator == 6)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    def test_execute_adc_absolute_y_page_boundary(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 5
-        registers.y_index = 3
-        registers.zero_flag = True
-        registers.negative_flag = True  
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0xBD 0x2100 and value at [0x2202] = 1
-            mock_memory_controller.read.side_effect = [0xff, 0x21, 1]
-
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x79, registers, mock_memory_controller)
-            self.assertEqual(count, 5)
-            self.assertTrue(registers.accumulator == 6)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    def test_execute_adc_indexed_indirect_x(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 5
-        registers.x_index = 3
-        registers.zero_flag = True
-        registers.negative_flag = True  
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0x61 0x03 and value at [0x06] = 0x1234, [0x1234] = 3
-            mock_memory_controller.read.side_effect = [3, 0x34, 0x12, 3]
-
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x61, registers, mock_memory_controller)
-            self.assertEqual(count, 6)
-            self.assertEqual(mock_memory_controller.read.call_count, 4)            
-            self.assertTrue(registers.accumulator == 8)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    def test_execute_adc_indirect_indexed_y(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 5
-        registers.y_index = 3
-        registers.zero_flag = True
-        registers.negative_flag = True  
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0x71 0x2a  memory at 0x2a = [0x28, 0x40], [0x402B] = 3
-            mock_memory_controller.read.side_effect = [0x2a, 0x28, 0x40, 3]
-
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x71, registers, mock_memory_controller)
-            self.assertEqual(count, 5)
-            self.assertEqual(mock_memory_controller.read.call_count, 4)            
-            self.assertTrue(registers.accumulator == 8)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    def test_execute_adc_indirect_indexed_y_page_boundary(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 5
-        registers.y_index = 3
-        registers.zero_flag = True
-        registers.negative_flag = True  
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # we're mocking 0x71 0x2a  memory at 0x2a = [0x28, 0x40], [0x4101] = 3
-            mock_memory_controller.read.side_effect = [0x2a, 0xfe, 0x40, 3]
-
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x71, registers, mock_memory_controller)
-            self.assertEqual(count, 6)
-            self.assertEqual(mock_memory_controller.read.call_count, 4)
-            self.assertTrue(registers.accumulator == 8)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-
-    def execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(self, actual_opcode, expected_clocks, mock_memory_controller, **kwargs):
-
-        opcode = OpCode()
-        registers = Registers()
-        setattr(registers,'accumulator',0x50)
-
-        if kwargs:
-            for arg in kwargs:
-                setattr(registers, arg, kwargs[arg])
-
-        # Mocking 0x150 - 0xf0 (borrow 'in')
+        mock_memory_controller.read.return_value = 0x22
         registers.pc += 1 #need to fake the cpu reading the opcode
         count = opcode.execute(actual_opcode, registers, mock_memory_controller)
-        self.assertEqual(count, expected_clocks)
-        self.assertEqual(registers.accumulator, 0x5f)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.negative_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.overflow_flag)
+        assert count == expected_clocks
+        assert registers.accumulator == 0x27
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
 
-    def test_execute_sbc_immediate_borrow_in_borrow_out_no_overflow_positive_result(self):
+def execute_adc_carry_set( actual_opcode, expected_clocks):
 
-        mock_memory_controller = Mock()
+    opcode = OpCode()
+    registers = Registers() 
+    registers.accumulator = 5
+    registers.zero_flag = True
+    registers.negative_flag = True  
+    registers.carry_flag = True  
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        mock_memory_controller.read.return_value = 0x22
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(actual_opcode, registers, mock_memory_controller)
+        assert count == expected_clocks
+        assert registers.accumulator == 0x28
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
+
+def execute_adc_should_set_carry( actual_opcode, expected_clocks):
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 1
+    registers.zero_flag = False
+    registers.negative_flag = True    
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        mock_memory_controller.read.return_value = 0xff
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(actual_opcode, registers, mock_memory_controller)
+        assert count == expected_clocks
+        assert registers.accumulator == 0
+        assert registers.zero_flag
+        assert registers.negative_flag == False
+        assert registers.carry_flag
+
+def test_execute_adc_immediate_carry_clear():
+
+    execute_adc_carry_clear(0x69, 2)
+
+def test_execute_adc_immediate_carry_set():
+
+    execute_adc_carry_set(0x69, 2)
+
+def test_execute_adc_immediate_should_set_carry():
+
+    execute_adc_should_set_carry(0x69, 2)
+
+def test_execute_adc_zeropage_carry_clear():
+
+    execute_adc_carry_clear(0x65, 3)
+
+def test_execute_adc_zeropage_carry_set():
+
+    execute_adc_carry_set(0x65, 3)
+
+def test_execute_adc_zeropage_should_set_carry():
+
+    execute_adc_should_set_carry(0x65, 3)
+
+# No need to test all combinations of carry, uses same code as
+# other immediate addressing modes
+def test_execute_adc_immediate_zp_x():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 5
+    registers.x_index = 3
+    registers.zero_flag = True
+    registers.negative_flag = True  
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xb5 0x21 and value at [0x0024] = 1
+        mock_memory_controller.read.side_effect = [0x21, 1]
+
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x75, registers, mock_memory_controller)
+        assert count == 4
+        assert registers.accumulator == 6
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
+
+# No need to test all combinations of carry, uses same code as
+# other immediate addressing modes
+def test_execute_adc_absolute():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 5
+    registers.zero_flag = True
+    registers.negative_flag = True  
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xb5 0x21 0x22 and value at [0x2221] = 1
+        mock_memory_controller.read.side_effect = [0x21, 0x22, 1]
+
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x6D, registers, mock_memory_controller)
+        assert count == 4
+        assert registers.accumulator == 6
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
+
+def test_execute_adc_absolute_x():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 5
+    registers.x_index = 3
+    registers.zero_flag = True
+    registers.negative_flag = True  
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xBD 0x2100 and value at [0x2103] = 1
+        mock_memory_controller.read.side_effect = [0, 0x21, 1]
+
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x7D, registers, mock_memory_controller)
+        assert count == 4
+        assert registers.accumulator == 6
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
+
+def test_execute_adc_absolute_x_page_boundary():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 5
+    registers.x_index = 3
+    registers.zero_flag = True
+    registers.negative_flag = True  
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xBD 0x2100 and value at [0x2202] = 1
+        mock_memory_controller.read.side_effect = [0xff, 0x21, 1]
+
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x7D, registers, mock_memory_controller)
+        assert count == 5
+        assert registers.accumulator == 6
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
+
+def test_execute_adc_absolute_y():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 5
+    registers.y_index = 3
+    registers.zero_flag = True
+    registers.negative_flag = True  
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xBD 0x2100 and value at [0x2103] = 1
+        mock_memory_controller.read.side_effect = [0, 0x21, 1]
+
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x79, registers, mock_memory_controller)
+        assert count == 4
+        assert registers.accumulator == 6
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
+
+def test_execute_adc_absolute_y_page_boundary():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 5
+    registers.y_index = 3
+    registers.zero_flag = True
+    registers.negative_flag = True  
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0xBD 0x2100 and value at [0x2202] = 1
+        mock_memory_controller.read.side_effect = [0xff, 0x21, 1]
+
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x79, registers, mock_memory_controller)
+        assert count == 5
+        assert registers.accumulator == 6
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
+
+def test_execute_adc_indexed_indirect_x():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 5
+    registers.x_index = 3
+    registers.zero_flag = True
+    registers.negative_flag = True  
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0x61 0x03 and value at [0x06] = 0x1234, [0x1234] = 3
+        mock_memory_controller.read.side_effect = [3, 0x34, 0x12, 3]
+
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x61, registers, mock_memory_controller)
+        assert count == 6
+        assert mock_memory_controller.read.call_count == 4            
+        assert registers.accumulator == 8
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
+
+def test_execute_adc_indirect_indexed_y():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 5
+    registers.y_index = 3
+    registers.zero_flag = True
+    registers.negative_flag = True  
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0x71 0x2a  memory at 0x2a = [0x28, 0x40], [0x402B] = 3
+        mock_memory_controller.read.side_effect = [0x2a, 0x28, 0x40, 3]
+
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x71, registers, mock_memory_controller)
+        assert count == 5
+        assert mock_memory_controller.read.call_count == 4            
+        assert registers.accumulator == 8
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
+
+def test_execute_adc_indirect_indexed_y_page_boundary():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 5
+    registers.y_index = 3
+    registers.zero_flag = True
+    registers.negative_flag = True  
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # we're mocking 0x71 0x2a  memory at 0x2a = [0x28, 0x40], [0x4101] = 3
+        mock_memory_controller.read.side_effect = [0x2a, 0xfe, 0x40, 3]
+
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x71, registers, mock_memory_controller)
+        assert count == 6
+        assert mock_memory_controller.read.call_count == 4
+        assert registers.accumulator == 8
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag == False
+
+def execute_sbc_borrow_in_borrow_out_no_overflow_positive_result( actual_opcode, expected_clocks, mock_memory_controller, **kwargs):
+
+    opcode = OpCode()
+    registers = Registers()
+    setattr(registers,'accumulator',0x50)
+
+    if kwargs:
+        for arg in kwargs:
+            setattr(registers, arg, kwargs[arg])
+
+    # Mocking 0x150 - 0xf0 (borrow 'in')
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(actual_opcode, registers, mock_memory_controller)
+    assert count == expected_clocks
+    assert registers.accumulator == 0x5f
+    assert registers.zero_flag == False
+    assert registers.negative_flag == False
+    assert registers.carry_flag == False
+    assert registers.overflow_flag == False
+
+def test_execute_sbc_immediate_borrow_in_borrow_out_no_overflow_positive_result():
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.return_value = 0xf0
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xE9, 2, mock_memory_controller)
+    assert mock_memory_controller.read.call_count == 1
+
+def test_execute_sbc_zeropage_borrow_in_borrow_out_no_overflow_positive_result():
+
+    mock_memory_controller = Mock()
+    # we're mocking 0xE5 0x20 and [0x20] = 0xf0
+    mock_memory_controller.read.side_effect = [0x20, 0xf0]
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xE5, 3, mock_memory_controller)
+    assert mock_memory_controller.read.call_count == 2
+
+def test_execute_sbc_zeropageX_borrow_in_borrow_out_no_overflow_positive_result():
+
+    mock_memory_controller = Mock()
+    # we're mocking 0xF5 0x20 and [0x23] = 0xf0
+    mock_memory_controller.read.side_effect = [0x20, 0xf0]
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xF5, 4, mock_memory_controller, x_index = 3)
+    assert mock_memory_controller.read.call_count == 2
+
+def test_execute_sbc_absolute_borrow_in_borrow_out_no_overflow_positive_result():
+
+    mock_memory_controller = Mock()
+    # we're mocking 0xED 0x0 0x20 and [0x2000] = 0xf0
+    mock_memory_controller.read.side_effect = [0, 0x20, 0xf0]
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xED, 4, mock_memory_controller)
+    assert mock_memory_controller.read.call_count == 3
+
+def test_execute_sbc_absoluteX_borrow_in_borrow_out_no_overflow_positive_result():
+
+    mock_memory_controller = Mock()
+    # we're mocking 0xFD 0x00 0x20 and [0x2003] = 0xf0
+    mock_memory_controller.read.side_effect = [0x00, 0x20, 0xf0]
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xFD, 4, mock_memory_controller, x_index = 3)
+    assert mock_memory_controller.read.call_count == 3
+
+def test_execute_sbc_absoluteX_borrow_in_borrow_out_no_overflow_positive_result_extra_cycle():
+
+    mock_memory_controller = Mock()
+    # we're mocking 0xFD 0xfe 0x20 and [0x2101] = 0xf0
+    mock_memory_controller.read.side_effect = [0xfe, 0x20, 0xf0]
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xFD, 5, mock_memory_controller, x_index = 3)
+    assert mock_memory_controller.read.call_count == 3
+
+def test_execute_sbc_absoluteY_borrow_in_borrow_out_no_overflow_positive_result():
+
+    mock_memory_controller = Mock()
+    # we're mocking 0xF9 0x00 0x20 and [0x2003] = 0xf0
+    mock_memory_controller.read.side_effect = [0x00, 0x20, 0xf0]
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xF9, 4, mock_memory_controller, y_index = 3)
+    assert mock_memory_controller.read.call_count == 3
+
+def test_execute_sbc_absoluteY_borrow_in_borrow_out_no_overflow_positive_result_extra_cycle():
+
+    mock_memory_controller = Mock()
+    # we're mocking 0xF9 0xfe 0x20 and [0x2101] = 0xf0
+    mock_memory_controller.read.side_effect = [0xfe, 0x20, 0xf0]
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xF9, 5, mock_memory_controller, y_index = 3)
+    assert mock_memory_controller.read.call_count == 3
+
+def test_execute_sbc_indirectX_borrow_in_borrow_out_no_overflow_positive_result():
+
+    mock_memory_controller = Mock()
+    # we're mocking 0xE1 0x20 and [0x23] = 0x1234 [0x1234] = 0xf0
+    mock_memory_controller.read.side_effect = [0x20, 0x34, 0x12, 0xf0]
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xE1, 6, mock_memory_controller, x_index = 3)
+    assert mock_memory_controller.read.call_count == 4
+
+def test_execute_sbc_indirectY_borrow_in_borrow_out_no_overflow_positive_result():
+
+    mock_memory_controller = Mock()
+    # we're mocking 0xF1 0x20 and [0x20] = 0x1234 [0x1237] = 0xf0
+    mock_memory_controller.read.side_effect = [0x44, 0x34, 0x12, 0xf0]
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xF1, 5, mock_memory_controller, y_index = 3)
+    assert mock_memory_controller.read.call_count == 4
+
+def test_execute_sbc_indirectY_borrow_in_borrow_out_no_overflow_positive_result_extra_cycle():
+
+    mock_memory_controller = Mock()
+    # we're mocking 0xF1 0x20 and [0x20] = 0x1234 [0x1301] = 0xf0
+    mock_memory_controller.read.side_effect = [0x44, 0xfe, 0x12, 0xf0]
+
+    execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xF1, 6, mock_memory_controller, y_index = 3)
+    assert mock_memory_controller.read.call_count == 4
+
+def test_execute_sbc_immediate_no_borrow_in_borrow_out_overflow_negative_result():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0x50
+    registers.carry_flag = True
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # Mocking 0xE9 0xb0 so subtracting 0x50 - 0xb0 (80 - -80)
+        mock_memory_controller.read.return_value = 0xb0
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xE9, registers, mock_memory_controller)
+        assert count == 2
+        assert registers.accumulator == 0xa0
+        assert registers.zero_flag == False
+        assert registers.negative_flag
+        assert registers.carry_flag == False
+        assert registers.overflow_flag
+
+def test_execute_sbc_immediate_borrow_in_borrow_out_no_overflow_negative_result():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0x50
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # Mocking 0xE9 0x70 so subtracting 0x150 - 0x70 (borrow 'in')
+        mock_memory_controller.read.return_value = 0x70
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xE9, registers, mock_memory_controller)
+        assert count == 2
+        assert registers.accumulator == 0xdf
+        assert registers.zero_flag == False
+        assert registers.negative_flag
+        assert registers.carry_flag == False
+        assert registers.overflow_flag == False
+
+def test_execute_sbc_immediate_no_borrow_in_no_borrow_out_no_overflow_positive_result():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0x50
+    registers.carry_flag = True
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # Mocking 0xE9 0x70 so subtracting 0x50 - 0x30 (80-48 = 32)
+        mock_memory_controller.read.return_value = 0x30
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xE9, registers, mock_memory_controller)
+        assert count == 2
+        assert registers.accumulator == 0x20
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag
+        assert registers.overflow_flag == False
+
+def test_execute_sbc_immediate_borrow_in_borrow_out_no_overflow_negative_result_2():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0xd0 #start with negative acc this time
+
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
+
+        # Mocking 0xE9 0x70 so subtracting 0xd0 - 0xf0 (-48 - -16 = -32)
         mock_memory_controller.read.return_value = 0xf0
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xE9, registers, mock_memory_controller)
+        assert count == 2
+        assert registers.accumulator == 0xdf
+        assert registers.zero_flag == False
+        assert registers.negative_flag
+        assert registers.carry_flag == False
+        assert registers.overflow_flag == False
 
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xE9, 2, mock_memory_controller)
-        self.assertEqual(mock_memory_controller.read.call_count, 1)
+def test_execute_sbc_immediate_no_borrow_in_no_borrow_out_no_overflow_positive_result_2():
 
-    def test_execute_sbc_zeropage_borrow_in_borrow_out_no_overflow_positive_result(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0xd0 #start with negative acc this time
+    registers.carry_flag = True
 
-        mock_memory_controller = Mock()
-        # we're mocking 0xE5 0x20 and [0x20] = 0xf0
-        mock_memory_controller.read.side_effect = [0x20, 0xf0]
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xE5, 3, mock_memory_controller)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
+        # Mocking 0xE9 0x70 so subtracting 0xd0 - 0xb0 (-48 - -80 = 32)
+        mock_memory_controller.read.return_value = 0xb0
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xE9, registers, mock_memory_controller)
+        assert count == 2
+        assert registers.accumulator == 0x20
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag
+        assert registers.overflow_flag == False
 
-    def test_execute_sbc_zeropageX_borrow_in_borrow_out_no_overflow_positive_result(self):
+def test_execute_sbc_immediate_borrow_in_no_borrow_out_overflow_positive_result():
 
-        mock_memory_controller = Mock()
-        # we're mocking 0xF5 0x20 and [0x23] = 0xf0
-        mock_memory_controller.read.side_effect = [0x20, 0xf0]
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0xd0 #start with negative acc this time
 
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xF5, 4, mock_memory_controller, x_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-    def test_execute_sbc_absolute_borrow_in_borrow_out_no_overflow_positive_result(self):
+        # Mocking 0xE9 0x70 so subtracting 0xd0 - 0x70 (-48 - 112 = 96 (overflow))
+        mock_memory_controller.read.return_value = 0x70
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xE9, registers, mock_memory_controller)
+        assert count == 2
+        assert registers.accumulator == 0x5f
+        assert registers.zero_flag == False
+        assert registers.negative_flag == False
+        assert registers.carry_flag
+        assert registers.overflow_flag
 
-        mock_memory_controller = Mock()
-        # we're mocking 0xED 0x0 0x20 and [0x2000] = 0xf0
-        mock_memory_controller.read.side_effect = [0, 0x20, 0xf0]
+def test_execute_sbc_immediate_no_borrow_in_no_borrow_out_no_overflow_negative_result():
 
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xED, 4, mock_memory_controller)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0xd0 #start with negative acc this time
+    registers.carry_flag = True
 
-    def test_execute_sbc_absoluteX_borrow_in_borrow_out_no_overflow_positive_result(self):
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        mock_memory_controller = Mock()
-        # we're mocking 0xFD 0x00 0x20 and [0x2003] = 0xf0
-        mock_memory_controller.read.side_effect = [0x00, 0x20, 0xf0]
-
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xFD, 4, mock_memory_controller, x_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-
-    def test_execute_sbc_absoluteX_borrow_in_borrow_out_no_overflow_positive_result_extra_cycle(self):
-
-        mock_memory_controller = Mock()
-        # we're mocking 0xFD 0xfe 0x20 and [0x2101] = 0xf0
-        mock_memory_controller.read.side_effect = [0xfe, 0x20, 0xf0]
-
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xFD, 5, mock_memory_controller, x_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-
-    def test_execute_sbc_absoluteY_borrow_in_borrow_out_no_overflow_positive_result(self):
-
-        mock_memory_controller = Mock()
-        # we're mocking 0xF9 0x00 0x20 and [0x2003] = 0xf0
-        mock_memory_controller.read.side_effect = [0x00, 0x20, 0xf0]
-
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xF9, 4, mock_memory_controller, y_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-
-    def test_execute_sbc_absoluteY_borrow_in_borrow_out_no_overflow_positive_result_extra_cycle(self):
-
-        mock_memory_controller = Mock()
-        # we're mocking 0xF9 0xfe 0x20 and [0x2101] = 0xf0
-        mock_memory_controller.read.side_effect = [0xfe, 0x20, 0xf0]
-
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xF9, 5, mock_memory_controller, y_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-
-    def test_execute_sbc_indirectX_borrow_in_borrow_out_no_overflow_positive_result(self):
-
-        mock_memory_controller = Mock()
-        # we're mocking 0xE1 0x20 and [0x23] = 0x1234 [0x1234] = 0xf0
-        mock_memory_controller.read.side_effect = [0x20, 0x34, 0x12, 0xf0]
-
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xE1, 6, mock_memory_controller, x_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 4)
-
-    def test_execute_sbc_indirectY_borrow_in_borrow_out_no_overflow_positive_result(self):
-
-        mock_memory_controller = Mock()
-        # we're mocking 0xF1 0x20 and [0x20] = 0x1234 [0x1237] = 0xf0
-        mock_memory_controller.read.side_effect = [0x44, 0x34, 0x12, 0xf0]
-
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xF1, 5, mock_memory_controller, y_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 4)
-
-    def test_execute_sbc_indirectY_borrow_in_borrow_out_no_overflow_positive_result_extra_cycle(self):
-
-        mock_memory_controller = Mock()
-        # we're mocking 0xF1 0x20 and [0x20] = 0x1234 [0x1301] = 0xf0
-        mock_memory_controller.read.side_effect = [0x44, 0xfe, 0x12, 0xf0]
-
-        self.execute_sbc_borrow_in_borrow_out_no_overflow_positive_result(0xF1, 6, mock_memory_controller, y_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 4)
-
-    def test_execute_sbc_immediate_no_borrow_in_borrow_out_overflow_negative_result(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0x50
-        registers.carry_flag = True
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # Mocking 0xE9 0xb0 so subtracting 0x50 - 0xb0 (80 - -80)
-            mock_memory_controller.read.return_value = 0xb0
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xE9, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            self.assertTrue(registers.accumulator == 0xa0)
-            self.assertFalse(registers.zero_flag)
-            self.assertTrue(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-            self.assertTrue(registers.overflow_flag)
-
-    def test_execute_sbc_immediate_borrow_in_borrow_out_no_overflow_negative_result(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0x50
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # Mocking 0xE9 0x70 so subtracting 0x150 - 0x70 (borrow 'in')
-            mock_memory_controller.read.return_value = 0x70
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xE9, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            self.assertEqual(registers.accumulator, 0xdf)
-            self.assertFalse(registers.zero_flag)
-            self.assertTrue(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-            self.assertFalse(registers.overflow_flag)
-
-    def test_execute_sbc_immediate_no_borrow_in_no_borrow_out_no_overflow_positive_result(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0x50
-        registers.carry_flag = True
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # Mocking 0xE9 0x70 so subtracting 0x50 - 0x30 (80-48 = 32)
-            mock_memory_controller.read.return_value = 0x30
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xE9, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            self.assertTrue(registers.accumulator == 0x20)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertTrue(registers.carry_flag)
-            self.assertFalse(registers.overflow_flag)
-
-    def test_execute_sbc_immediate_borrow_in_borrow_out_no_overflow_negative_result_2(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0xd0 #start with negative acc this time
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # Mocking 0xE9 0x70 so subtracting 0xd0 - 0xf0 (-48 - -16 = -32)
-            mock_memory_controller.read.return_value = 0xf0
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xE9, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            self.assertEqual(registers.accumulator, 0xdf)
-            self.assertFalse(registers.zero_flag)
-            self.assertTrue(registers.negative_flag)
-            self.assertFalse(registers.carry_flag)
-            self.assertFalse(registers.overflow_flag)
-
-    def test_execute_sbc_immediate_no_borrow_in_no_borrow_out_no_overflow_positive_result_2(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0xd0 #start with negative acc this time
-        registers.carry_flag = True
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # Mocking 0xE9 0x70 so subtracting 0xd0 - 0xb0 (-48 - -80 = 32)
-            mock_memory_controller.read.return_value = 0xb0
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xE9, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            self.assertTrue(registers.accumulator == 0x20)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertTrue(registers.carry_flag)
-            self.assertFalse(registers.overflow_flag)
-
-    def test_execute_sbc_immediate_borrow_in_no_borrow_out_overflow_positive_result(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0xd0 #start with negative acc this time
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # Mocking 0xE9 0x70 so subtracting 0xd0 - 0x70 (-48 - 112 = 96 (overflow))
-            mock_memory_controller.read.return_value = 0x70
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xE9, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            self.assertEqual(registers.accumulator, 0x5f)
-            self.assertFalse(registers.zero_flag)
-            self.assertFalse(registers.negative_flag)
-            self.assertTrue(registers.carry_flag)
-            self.assertTrue(registers.overflow_flag)
-
-    def test_execute_sbc_immediate_no_borrow_in_no_borrow_out_no_overflow_negative_result(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0xd0 #start with negative acc this time
-        registers.carry_flag = True
-
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
-
-            # Mocking 0xE9 0x30 so subtracting 0xd0 - 0x30 (-48 - 48 = -96)
-            mock_memory_controller.read.return_value = 0x30
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xE9, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            self.assertTrue(registers.accumulator == 0xa0)
-            self.assertFalse(registers.zero_flag)
-            self.assertTrue(registers.negative_flag)
-            self.assertTrue(registers.carry_flag)
-            self.assertFalse(registers.overflow_flag)
-
-if __name__ == '__main__':
-    unittest.main()
+        # Mocking 0xE9 0x30 so subtracting 0xd0 - 0x30 (-48 - 48 = -96)
+        mock_memory_controller.read.return_value = 0x30
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xE9, registers, mock_memory_controller)
+        assert count == 2
+        assert registers.accumulator == 0xa0
+        assert registers.zero_flag == False
+        assert registers.negative_flag
+        assert registers.carry_flag
+        assert registers.overflow_flag == False

--- a/tests/test_bitshift_opcodes.py
+++ b/tests/test_bitshift_opcodes.py
@@ -6,330 +6,325 @@ from emupy6502.registers import Registers
 from emupy6502.opcodes import OpCode
 
 
-class OpCodeTestsBitShifts(unittest.TestCase):
-
-    def test_execute_asl_accumulator_positive(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 3
-
-        mock_memory_controller = Mock()
-
-        # we're mocking 0x0A 0x21 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x0A, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        mock_memory_controller.read.assert_not_called()
-        self.assertEqual(registers.pc, 1)
-        self.assertEqual(registers.accumulator, 6)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_asl_accumulator_negative(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = -3
-
-        mock_memory_controller = Mock()
-
-        # we're mocking 0x0A 0x21 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x0A, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        mock_memory_controller.read.assert_not_called()
-        self.assertEqual(registers.pc, 1)
-        self.assertEqual(registers.accumulator, 0xfa)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)
-
-    def test_execute_asl_zeropage(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        mock_memory_controller = Mock()
-
-        # we're mocking 0x06 0x30
-        mock_memory_controller.read.side_effect = [0x30, 0x20]
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x06, registers, mock_memory_controller)
-        self.assertEqual(count, 5)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        mock_memory_controller.write.assert_called_with(0x30, 0x40)
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)        
-
-    def test_execute_asl_zeropage_x(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.x_index = 3
-
-        mock_memory_controller = Mock()
-
-        # we're mocking 0x16 0x21 so store to [0x0024]
-        mock_memory_controller.read.side_effect = [0x21, 0x10]
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x16, registers, mock_memory_controller)
-        self.assertEqual(count, 6)
-
-        # these are checked more thoroughly in addressing_modes_tests
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        mock_memory_controller.write.assert_called_with(0x24, 0x20)
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)        
-
-    def test_execute_asl_zeropage_x_wrap(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.x_index = 3
-
-        mock_memory_controller = Mock()
-
-        # we're mocking 0x16 0x21 so store to [0x0024]
-        mock_memory_controller.read.side_effect = [0xfe, 0xf0]
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x16, registers, mock_memory_controller)
-        self.assertEqual(count, 6)
-
-        # these are checked more thoroughly in addressing_modes_tests
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        mock_memory_controller.write.assert_called_with(0x01, 0xe0)
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)        
-
-    def test_execute_asl_absolute(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0x20
-
-        mock_memory_controller = Mock()
-
-        # we're mocking 0x0E 0x0 0x20 so store to [0x2000]
-        mock_memory_controller.read.side_effect = [0, 0x20, 0x21]
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x0E, registers, mock_memory_controller)
-        self.assertEqual(count, 6)
-
-        # these are checked more thoroughly in addressing_modes_tests
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        mock_memory_controller.write.assert_called_with(0x2000, 0x42)
-        self.assertEqual(registers.pc, 3)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)        
-
-    def test_execute_asl_absolute_x(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.x_index = 3
-
-        mock_memory_controller = Mock()
-
-        # we're mocking 0x1E 0x2100 so write is to [0x2103]
-        mock_memory_controller.read.side_effect = [0, 0x21, 0xfe]
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x1E, registers, mock_memory_controller)
-        self.assertEqual(count, 7)
-
-        # these are checked more thoroughly in addressing_modes_tests
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-        mock_memory_controller.write.assert_called_with(0x2103, 0xfc)
-        self.assertEqual(registers.pc, 3)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)        
-
-    def test_execute_rol_accumulator_carry_clear_sign_clear(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 3
-
-        mock_memory_controller = Mock()
-
-        # we're mocking 0x2A
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x2A, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        mock_memory_controller.read.assert_not_called()
-        self.assertEqual(registers.pc, 1)
-        self.assertEqual(registers.accumulator, 6)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_rol_accumulator_carry_set_sign_clear(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 3
-        registers.carry_flag = True
-
-        mock_memory_controller = Mock()
-
-        # we're mocking 0x2A
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x2A, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        mock_memory_controller.read.assert_not_called()
-        self.assertEqual(registers.pc, 1)
-        self.assertEqual(registers.accumulator, 7)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_rol_accumulator_carry_clear_sign_set(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0xc0
-
-        mock_memory_controller = Mock()
-
-        # we're mocking 0x2A
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x2A, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        mock_memory_controller.read.assert_not_called()
-        self.assertEqual(registers.pc, 1)
-        self.assertEqual(registers.accumulator, 0x80)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)
-
-    def test_execute_rol_zeropage_carry_clear_sign_clear(self):
-
-        opcode = OpCode()
-        registers = Registers()
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x30, 3]
-
-        # we're mocking 0x26 0x30 and [0x30] = 3
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x26, registers, mock_memory_controller)
-        self.assertEqual(count, 5)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        mock_memory_controller.write.assert_called_with(0x30, 6)
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_rol_zeropage_carry_set_sign_clear(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.carry_flag = True
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x30, 3]
-
-        # we're mocking 0x26 0x30 and [0x30] = 3
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x26, registers, mock_memory_controller)
-        self.assertEqual(count, 5)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)        
-        mock_memory_controller.write.assert_called_with(0x30, 7)
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_rol_zeropage_carry_clear_sign_set(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0xc0
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x30, 0xc0]
-
-        # we're mocking 0x26 0x30 and [0x30] = 0xc0
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x26, registers, mock_memory_controller)
-        self.assertEqual(count, 5)
-        mock_memory_controller.write.assert_called_with(0x30, 0x80)
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)
-
-    def test_execute_rol_absolute_carry_clear_sign_clear(self):
-
-        opcode = OpCode()
-        registers = Registers()
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x00, 0x30, 3]
-
-        # we're mocking 0x2E 0x30 and [0x3000] = 3
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x2E, registers, mock_memory_controller)
-        self.assertEqual(count, 6)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-        mock_memory_controller.write.assert_called_with(0x3000, 6)
-        self.assertEqual(registers.pc, 3)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_rol_absolute_carry_set_sign_clear(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.carry_flag = True
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x00, 0x30, 3]
-
-        # we're mocking 0x2E 0x30 and [0x3000] = 3
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x2E, registers, mock_memory_controller)
-        self.assertEqual(count, 6)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-        mock_memory_controller.write.assert_called_with(0x3000, 7)
-        self.assertEqual(registers.pc, 3)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_rol_absolute_carry_clear_sign_set(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 0xc0
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x00, 0x30, 0xc0]
-
-        # we're mocking 0x2E 0x30 and [0x3000] = 3
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0x2E, registers, mock_memory_controller)
-        self.assertEqual(count, 6)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-        mock_memory_controller.write.assert_called_with(0x3000, 0x80)
-        self.assertEqual(registers.pc, 3)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)
-
-if __name__ == '__main__':
-    unittest.main()
+def test_execute_asl_accumulator_positive():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 3
+
+    mock_memory_controller = Mock()
+
+    # we're mocking 0x0A 0x21 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x0A, registers, mock_memory_controller)
+    assert count == 2
+    mock_memory_controller.read.assert_not_called()
+    assert registers.pc == 1
+    assert registers.accumulator == 6
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag == False
+
+def test_execute_asl_accumulator_negative():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = -3
+
+    mock_memory_controller = Mock()
+
+    # we're mocking 0x0A 0x21 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x0A, registers, mock_memory_controller)
+    assert count == 2
+    mock_memory_controller.read.assert_not_called()
+    assert registers.pc == 1
+    assert registers.accumulator == 0xfa
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag
+
+def test_execute_asl_zeropage():
+
+    opcode = OpCode()
+    registers = Registers()
+    mock_memory_controller = Mock()
+
+    # we're mocking 0x06 0x30
+    mock_memory_controller.read.side_effect = [0x30, 0x20]
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x06, registers, mock_memory_controller)
+    assert count == 5
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    mock_memory_controller.write.assert_called_with(0x30, 0x40)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag == False        
+
+def test_execute_asl_zeropage_x():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.x_index = 3
+
+    mock_memory_controller = Mock()
+
+    # we're mocking 0x16 0x21 so store to [0x0024]
+    mock_memory_controller.read.side_effect = [0x21, 0x10]
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x16, registers, mock_memory_controller)
+    assert count == 6
+
+    # these are checked more thoroughly in addressing_modes_tests
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    mock_memory_controller.write.assert_called_with(0x24, 0x20)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag == False        
+
+def test_execute_asl_zeropage_x_wrap():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.x_index = 3
+
+    mock_memory_controller = Mock()
+
+    # we're mocking 0x16 0x21 so store to [0x0024]
+    mock_memory_controller.read.side_effect = [0xfe, 0xf0]
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x16, registers, mock_memory_controller)
+    assert count == 6
+
+    # these are checked more thoroughly in addressing_modes_tests
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    mock_memory_controller.write.assert_called_with(0x01, 0xe0)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag        
+
+def test_execute_asl_absolute():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0x20
+
+    mock_memory_controller = Mock()
+
+    # we're mocking 0x0E 0x0 0x20 so store to [0x2000]
+    mock_memory_controller.read.side_effect = [0, 0x20, 0x21]
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x0E, registers, mock_memory_controller)
+    assert count == 6
+
+    # these are checked more thoroughly in addressing_modes_tests
+    assert mock_memory_controller.read.call_count == 3
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    mock_memory_controller.write.assert_called_with(0x2000, 0x42)
+    assert registers.pc == 3
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag == False        
+
+def test_execute_asl_absolute_x():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.x_index = 3
+
+    mock_memory_controller = Mock()
+
+    # we're mocking 0x1E 0x2100 so write is to [0x2103]
+    mock_memory_controller.read.side_effect = [0, 0x21, 0xfe]
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x1E, registers, mock_memory_controller)
+    assert count == 7
+
+    # these are checked more thoroughly in addressing_modes_tests
+    assert mock_memory_controller.read.call_count == 3
+    mock_memory_controller.write.assert_called_with(0x2103, 0xfc)
+    assert registers.pc == 3
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag        
+
+def test_execute_rol_accumulator_carry_clear_sign_clear():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 3
+
+    mock_memory_controller = Mock()
+
+    # we're mocking 0x2A
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x2A, registers, mock_memory_controller)
+    assert count == 2
+    mock_memory_controller.read.assert_not_called()
+    assert registers.pc == 1
+    assert registers.accumulator == 6
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag == False
+
+def test_execute_rol_accumulator_carry_set_sign_clear():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 3
+    registers.carry_flag = True
+
+    mock_memory_controller = Mock()
+
+    # we're mocking 0x2A
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x2A, registers, mock_memory_controller)
+    assert count == 2
+    mock_memory_controller.read.assert_not_called()
+    assert registers.pc == 1
+    assert registers.accumulator == 7
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag == False
+
+def test_execute_rol_accumulator_carry_clear_sign_set():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0xc0
+
+    mock_memory_controller = Mock()
+
+    # we're mocking 0x2A
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x2A, registers, mock_memory_controller)
+    assert count == 2
+    mock_memory_controller.read.assert_not_called()
+    assert registers.pc == 1
+    assert registers.accumulator == 0x80
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag
+
+def test_execute_rol_zeropage_carry_clear_sign_clear():
+
+    opcode = OpCode()
+    registers = Registers()
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x30, 3]
+
+    # we're mocking 0x26 0x30 and [0x30] = 3
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x26, registers, mock_memory_controller)
+    assert count == 5
+    assert mock_memory_controller.read.call_count == 2
+    mock_memory_controller.write.assert_called_with(0x30, 6)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag == False
+
+def test_execute_rol_zeropage_carry_set_sign_clear():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.carry_flag = True
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x30, 3]
+
+    # we're mocking 0x26 0x30 and [0x30] = 3
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x26, registers, mock_memory_controller)
+    assert count == 5
+    assert mock_memory_controller.read.call_count == 2        
+    mock_memory_controller.write.assert_called_with(0x30, 7)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag == False
+
+def test_execute_rol_zeropage_carry_clear_sign_set():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0xc0
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x30, 0xc0]
+
+    # we're mocking 0x26 0x30 and [0x30] = 0xc0
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x26, registers, mock_memory_controller)
+    assert count == 5
+    mock_memory_controller.write.assert_called_with(0x30, 0x80)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag
+
+def test_execute_rol_absolute_carry_clear_sign_clear():
+
+    opcode = OpCode()
+    registers = Registers()
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x00, 0x30, 3]
+
+    # we're mocking 0x2E 0x30 and [0x3000] = 3
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x2E, registers, mock_memory_controller)
+    assert count == 6
+    assert mock_memory_controller.read.call_count == 3
+    mock_memory_controller.write.assert_called_with(0x3000, 6)
+    assert registers.pc == 3
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag == False
+
+def test_execute_rol_absolute_carry_set_sign_clear():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.carry_flag = True
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x00, 0x30, 3]
+
+    # we're mocking 0x2E 0x30 and [0x3000] = 3
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x2E, registers, mock_memory_controller)
+    assert count == 6
+    assert mock_memory_controller.read.call_count == 3
+    mock_memory_controller.write.assert_called_with(0x3000, 7)
+    assert registers.pc == 3
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag == False
+
+def test_execute_rol_absolute_carry_clear_sign_set():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 0xc0
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x00, 0x30, 0xc0]
+
+    # we're mocking 0x2E 0x30 and [0x3000] = 3
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0x2E, registers, mock_memory_controller)
+    assert count == 6
+    assert mock_memory_controller.read.call_count == 3
+    mock_memory_controller.write.assert_called_with(0x3000, 0x80)
+    assert registers.pc == 3
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag

--- a/tests/test_compare_opcodes.py
+++ b/tests/test_compare_opcodes.py
@@ -6,376 +6,371 @@ from emupy6502.registers import Registers
 from emupy6502.opcodes import OpCode
 
 
-class OpCodeTestsCompares(unittest.TestCase):
-
-    def test_execute_cmp_immediate_lessthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 3
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21]
-
-        # we're mocking 0xC9 0x21 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC9, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        self.assertEqual(mock_memory_controller.read.call_count, 1)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)
-
-    def test_execute_cmp_immediate_greaterthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x3]
-
-        # we're mocking 0xC9 0x21 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC9, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        self.assertEqual(mock_memory_controller.read.call_count, 1)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cmp_immediate_equalto(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x4]
-
-        # we're mocking 0xC9 0x21 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC9, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        self.assertEqual(mock_memory_controller.read.call_count, 1)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(registers.pc, 2)
-        self.assertTrue(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cpx_immediate_lessthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.x_index = 3
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21]
-
-        # we're mocking 0xE0 0x21 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xE0, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        self.assertEqual(mock_memory_controller.read.call_count, 1)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)
-
-    def test_execute_cpx_immediate_greaterthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.x_index = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x3]
-
-        # we're mocking 0xE0 0x03 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xE0, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        self.assertEqual(mock_memory_controller.read.call_count, 1)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cpx_immediate_equalto(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.x_index = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x4]
-
-        # we're mocking 0xE0 0x04 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xE0, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        self.assertEqual(mock_memory_controller.read.call_count, 1)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(registers.pc, 2)
-        self.assertTrue(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cpy_immediate_lessthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.y_index = 3
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21]
-
-        # we're mocking 0xC0 0x21 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC0, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        self.assertEqual(mock_memory_controller.read.call_count, 1)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)
-
-    def test_execute_cpy_immediate_greaterthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.y_index = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x3]
-
-        # we're mocking 0xE0 0x03 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC0, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        self.assertEqual(mock_memory_controller.read.call_count, 1)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cpy_immediate_equalto(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.y_index = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x4]
-
-        # we're mocking 0xE0 0x04 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC0, registers, mock_memory_controller)
-        self.assertEqual(count, 2)
-        self.assertEqual(mock_memory_controller.read.call_count, 1)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(registers.pc, 2)
-        self.assertTrue(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cmp_zeropage_lessthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 3
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 6]
-
-        # we're mocking 0xC5 0x21 and [0x21] = 6
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC5, registers, mock_memory_controller)
-        self.assertEqual(count, 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)
-
-    def test_execute_cmp_zeropage_greaterthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 0x3]
-
-        # we're mocking 0xC5 0x21 and [0x21] = 3
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC5, registers, mock_memory_controller)
-        self.assertEqual(count, 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cmp_zeropage_equalto(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.accumulator = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 0x4]
-
-        # we're mocking 0xC5 0x21 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC5, registers, mock_memory_controller)
-        self.assertEqual(count, 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        self.assertEqual(registers.pc, 2)
-        self.assertTrue(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cpx_zeropage_lessthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.x_index = 3
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 6]
-
-        # we're mocking 0xE4 0x21 and [0x21] = 6
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xE4, registers, mock_memory_controller)
-        self.assertEqual(count, 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)
-
-    def test_execute_cpx_zeropage_greaterthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.x_index = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 0x3]
-
-        # we're mocking 0xE4 0x21 and [0x21] = 3
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xE4, registers, mock_memory_controller)
-        self.assertEqual(count, 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cpx_zeropage_equalto(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.x_index = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 0x4]
-
-        # we're mocking 0xE4 0x21 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xE4, registers, mock_memory_controller)
-        self.assertEqual(count, 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        self.assertEqual(registers.pc, 2)
-        self.assertTrue(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cpy_zeropage_lessthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.y_index = 3
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 6]
-
-        # we're mocking 0xC4 0x21 and [0x21] = 6
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC4, registers, mock_memory_controller)
-        self.assertEqual(count, 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.carry_flag)
-        self.assertTrue(registers.negative_flag)
-
-    def test_execute_cpy_zeropage_greaterthan(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.y_index = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 0x3]
-
-        # we're mocking 0xC4 0x21 and [0x21] = 3
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC4, registers, mock_memory_controller)
-        self.assertEqual(count, 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-    def test_execute_cpy_zeropage_equalto(self):
-
-        opcode = OpCode()
-        registers = Registers()
-        registers.y_index = 4
-
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 0x4]
-
-        # we're mocking 0xC4 0x21 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC4, registers, mock_memory_controller)
-        self.assertEqual(count, 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        self.assertEqual(registers.pc, 2)
-        self.assertTrue(registers.zero_flag)
-        self.assertTrue(registers.carry_flag)
-        self.assertFalse(registers.negative_flag)
-
-if __name__ == '__main__':
-    unittest.main()
+def test_execute_cmp_immediate_lessthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 3
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21]
+
+    # we're mocking 0xC9 0x21 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC9, registers, mock_memory_controller)
+    assert count == 2
+    assert mock_memory_controller.read.call_count == 1
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag
+
+def test_execute_cmp_immediate_greaterthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x3]
+
+    # we're mocking 0xC9 0x21 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC9, registers, mock_memory_controller)
+    assert count == 2
+    assert mock_memory_controller.read.call_count == 1
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cmp_immediate_equalto():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x4]
+
+    # we're mocking 0xC9 0x21 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC9, registers, mock_memory_controller)
+    assert count == 2
+    assert mock_memory_controller.read.call_count == 1
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert registers.pc == 2
+    assert registers.zero_flag
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cpx_immediate_lessthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.x_index = 3
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21]
+
+    # we're mocking 0xE0 0x21 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xE0, registers, mock_memory_controller)
+    assert count == 2
+    assert mock_memory_controller.read.call_count == 1
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag
+
+def test_execute_cpx_immediate_greaterthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.x_index = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x3]
+
+    # we're mocking 0xE0 0x03 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xE0, registers, mock_memory_controller)
+    assert count == 2
+    assert mock_memory_controller.read.call_count == 1
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cpx_immediate_equalto():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.x_index = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x4]
+
+    # we're mocking 0xE0 0x04 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xE0, registers, mock_memory_controller)
+    assert count == 2
+    assert mock_memory_controller.read.call_count == 1
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert registers.pc == 2
+    assert registers.zero_flag
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cpy_immediate_lessthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.y_index = 3
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21]
+
+    # we're mocking 0xC0 0x21 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC0, registers, mock_memory_controller)
+    assert count == 2
+    assert mock_memory_controller.read.call_count == 1
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag
+
+def test_execute_cpy_immediate_greaterthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.y_index = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x3]
+
+    # we're mocking 0xE0 0x03 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC0, registers, mock_memory_controller)
+    assert count == 2
+    assert mock_memory_controller.read.call_count == 1
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cpy_immediate_equalto():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.y_index = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x4]
+
+    # we're mocking 0xE0 0x04 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC0, registers, mock_memory_controller)
+    assert count == 2
+    assert mock_memory_controller.read.call_count == 1
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert registers.pc == 2
+    assert registers.zero_flag
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cmp_zeropage_lessthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 3
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 6]
+
+    # we're mocking 0xC5 0x21 and [0x21] = 6
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC5, registers, mock_memory_controller)
+    assert count == 3
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag
+
+def test_execute_cmp_zeropage_greaterthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 0x3]
+
+    # we're mocking 0xC5 0x21 and [0x21] = 3
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC5, registers, mock_memory_controller)
+    assert count == 3
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cmp_zeropage_equalto():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.accumulator = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 0x4]
+
+    # we're mocking 0xC5 0x21 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC5, registers, mock_memory_controller)
+    assert count == 3
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    assert registers.pc == 2
+    assert registers.zero_flag
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cpx_zeropage_lessthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.x_index = 3
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 6]
+
+    # we're mocking 0xE4 0x21 and [0x21] = 6
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xE4, registers, mock_memory_controller)
+    assert count == 3
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag
+
+def test_execute_cpx_zeropage_greaterthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.x_index = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 0x3]
+
+    # we're mocking 0xE4 0x21 and [0x21] = 3
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xE4, registers, mock_memory_controller)
+    assert count == 3
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cpx_zeropage_equalto():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.x_index = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 0x4]
+
+    # we're mocking 0xE4 0x21 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xE4, registers, mock_memory_controller)
+    assert count == 3
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    assert registers.pc == 2
+    assert registers.zero_flag
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cpy_zeropage_lessthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.y_index = 3
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 6]
+
+    # we're mocking 0xC4 0x21 and [0x21] = 6
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC4, registers, mock_memory_controller)
+    assert count == 3
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag == False
+    assert registers.negative_flag
+
+def test_execute_cpy_zeropage_greaterthan():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.y_index = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 0x3]
+
+    # we're mocking 0xC4 0x21 and [0x21] = 3
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC4, registers, mock_memory_controller)
+    assert count == 3
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.carry_flag
+    assert registers.negative_flag == False
+
+def test_execute_cpy_zeropage_equalto():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.y_index = 4
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 0x4]
+
+    # we're mocking 0xC4 0x21 
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC4, registers, mock_memory_controller)
+    assert count == 3
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    assert registers.pc == 2
+    assert registers.zero_flag
+    assert registers.carry_flag
+    assert registers.negative_flag == False

--- a/tests/test_implied_opcodes.py
+++ b/tests/test_implied_opcodes.py
@@ -6,280 +6,275 @@ from emupy6502.registers import Registers
 from emupy6502.opcodes import OpCode
 
 
-class OpCodeTests(unittest.TestCase):
+def test_execute_nop():
+
+    opcode = OpCode()
+    registers = Registers()
+
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0xEA, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers == Registers()
+
+def test_execute_brk():
+
+    opcode = OpCode()
+    registers = Registers()
+    registers.sp = 0x200
+
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x00, 0x21]
+
+    registers.pc += 1 #need to fake the cpu reading the opcode        
+    count = opcode.execute(0x0, registers, mock_memory_controller)
+    assert count == 7
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.write.call_count == 3
+    assert mock_memory_controller.write.call_args_list[0], unittest.mock.call(0x200 == 1)
+    assert mock_memory_controller.write.call_args_list[1], unittest.mock.call(0x1ff == 0)
+    assert mock_memory_controller.write.call_args_list[2], unittest.mock.call(0x1fe == registers.status_register())
+    assert registers.pc == 0x2100
+
+def test_execute_tax():
+
+    opcode = OpCode()
+    registers = Registers()
+    dummy_value = 0x7c # (positive, not zero)
+    registers.accumulator =  dummy_value
+
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0xAA, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers.accumulator == dummy_value
+        assert registers.accumulator == registers.x_index
+        assert registers.negative_flag == False
+        assert registers.zero_flag == False
+
+def test_execute_tay():
+
+    opcode = OpCode()
+    registers = Registers()
+    dummy_value = 0x7c # (positive, not zero)
+    registers.accumulator =  dummy_value
+
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0xA8, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers.accumulator == dummy_value
+        assert registers.accumulator == registers.y_index
+        assert registers.negative_flag == False
+        assert registers.zero_flag == False
+
+def test_execute_txa():
+
+    opcode = OpCode()
+    registers = Registers()
+    dummy_value = 0x7c # (positive, not zero)
+    registers.x_index =  dummy_value
+
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0x8A, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers.x_index == dummy_value
+        assert registers.accumulator == registers.x_index
+        assert registers.negative_flag == False
+        assert registers.zero_flag == False
+
+def test_execute_tya():
+
+    opcode = OpCode()
+    registers = Registers()
+    dummy_value = 0x7c # (positive, not zero)
+    registers.y_index =  dummy_value
+
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0x98, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers.y_index == dummy_value
+        assert registers.accumulator == registers.y_index
+        assert registers.negative_flag == False
+        assert registers.zero_flag == False
+
+def test_execute_tsx():
+
+    opcode = OpCode()
+    registers = Registers() # leave sp with default
+    old_sp = registers.sp
+
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0xBA, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers.x_index == old_sp
+        assert registers.sp == old_sp
+        assert registers.negative_flag # default sp should be $fd
+        assert registers.zero_flag == False
+
+def test_execute_txs():
+
+    opcode = OpCode()
+    registers = Registers() 
+    dummy_value = 0x7c # (positive, not zero)
+    registers.x_index = dummy_value
+
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0x9A, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers.x_index == dummy_value
+        assert registers.sp == dummy_value
+        assert registers.negative_flag == False # default sp should be $fd
+        assert registers.zero_flag == False
+
+def test_execute_inx_0_to_1():
+
+    opcode = OpCode()
+    registers = Registers() 
+    dummy_value = 0x0
+    registers.x_index = dummy_value
+
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0xE8, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers.x_index == dummy_value + 1
+        assert registers.negative_flag == False
+        assert registers.zero_flag == False
+
+def test_execute_inx_127_to_128():
+
+    opcode = OpCode()
+    registers = Registers() 
+    dummy_value = 0x7f
+    registers.x_index = dummy_value
     
-    def test_execute_nop(self):
+    opcode.execute(0xE8, registers, None)
+    assert registers.x_index == dummy_value + 1
+    assert registers.negative_flag
+    assert registers.zero_flag == False
 
-        opcode = OpCode()
-        registers = Registers()
+def test_execute_inx_255_to_0():
 
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0xEA, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertTrue(registers == Registers())
+    opcode = OpCode()
+    registers = Registers() 
+    registers.x_index = 0xff
 
-    def test_execute_brk(self):
+    opcode.execute(0xE8, registers, None)
+    assert registers.x_index == 0
+    assert registers.negative_flag == False
+    assert registers.zero_flag
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.sp = 0x200
+def test_execute_iny_0_to_1():
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x00, 0x21]
+    opcode = OpCode()
+    registers = Registers() 
+    dummy_value = 0x0
+    registers.y_index = dummy_value
 
-        registers.pc += 1 #need to fake the cpu reading the opcode        
-        count = opcode.execute(0x0, registers, mock_memory_controller)
-        self.assertEqual(count, 7)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.write.call_count, 3)
-        self.assertEqual(mock_memory_controller.write.call_args_list[0], unittest.mock.call(0x200, 1))
-        self.assertEqual(mock_memory_controller.write.call_args_list[1], unittest.mock.call(0x1ff, 0))
-        self.assertEqual(mock_memory_controller.write.call_args_list[2], unittest.mock.call(0x1fe, registers.status_register()))
-        self.assertEqual(registers.pc, 0x2100)
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0xC8, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers.y_index == dummy_value + 1
+        assert registers.negative_flag == False
+        assert registers.zero_flag == False
 
-    def test_execute_tax(self):
+def test_execute_iny_127_to_128():
 
-        opcode = OpCode()
-        registers = Registers()
-        dummy_value = 0x7c # (positive, not zero)
-        registers.accumulator =  dummy_value
+    opcode = OpCode()
+    registers = Registers() 
+    dummy_value = 0x7f
+    registers.y_index = dummy_value
+    
+    opcode.execute(0xC8, registers, None)
+    assert registers.y_index == dummy_value + 1
+    assert registers.negative_flag
+    assert registers.zero_flag == False
 
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0xAA, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertEqual(registers.accumulator, dummy_value)
-            self.assertEqual(registers.accumulator, registers.x_index)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.zero_flag)
+def test_execute_iny_255_to_0():
 
-    def test_execute_tay(self):
+    opcode = OpCode()
+    registers = Registers() 
+    registers.y_index = 0xff
 
-        opcode = OpCode()
-        registers = Registers()
-        dummy_value = 0x7c # (positive, not zero)
-        registers.accumulator =  dummy_value
+    opcode.execute(0xC8, registers, None)
+    assert registers.y_index == 0
+    assert registers.negative_flag == False
+    assert registers.zero_flag
 
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0xA8, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertEqual(registers.accumulator, dummy_value)
-            self.assertEqual(registers.accumulator, registers.y_index)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.zero_flag)
+def test_execute_dex_1_to_0():
 
-    def test_execute_txa(self):
+    opcode = OpCode()
+    registers = Registers() 
+    registers.x_index = 1
 
-        opcode = OpCode()
-        registers = Registers()
-        dummy_value = 0x7c # (positive, not zero)
-        registers.x_index =  dummy_value
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0xCA, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers.x_index == 0
+        assert registers.negative_flag == False
+        assert registers.zero_flag
 
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0x8A, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertEqual(registers.x_index, dummy_value)
-            self.assertEqual(registers.accumulator, registers.x_index)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.zero_flag)
+def test_execute_dex_128_to_127():
 
-    def test_execute_tya(self):
+    opcode = OpCode()
+    registers = Registers() 
+    registers.x_index = 0x80
+    
+    opcode.execute(0xCA, registers, None)
+    assert registers.x_index == 0x7f
+    assert registers.negative_flag == False
+    assert registers.zero_flag == False
 
-        opcode = OpCode()
-        registers = Registers()
-        dummy_value = 0x7c # (positive, not zero)
-        registers.y_index =  dummy_value
+def test_execute_dex_0_to_minus1():
 
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0x98, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertEqual(registers.y_index, dummy_value)
-            self.assertEqual(registers.accumulator, registers.y_index)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.zero_flag)
+    opcode = OpCode()
+    registers = Registers() 
+    registers.x_index = 0
 
-    def test_execute_tsx(self):
+    opcode.execute(0xCA, registers, None)
+    assert registers.x_index == 255
+    assert registers.negative_flag
+    assert registers.zero_flag == False
 
-        opcode = OpCode()
-        registers = Registers() # leave sp with default
-        old_sp = registers.sp
+def test_execute_dey_1_to_0():
 
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0xBA, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertEqual(registers.x_index, old_sp)
-            self.assertEqual(registers.sp, old_sp)
-            self.assertTrue(registers.negative_flag) # default sp should be $fd
-            self.assertFalse(registers.zero_flag)
+    opcode = OpCode()
+    registers = Registers() 
+    registers.y_index = 1
 
-    def test_execute_txs(self):
+    with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
+        count = opcode.execute(0x88, registers, mock_memory_controller)
+        assert count == 2
+        mock_memory_controller.assert_not_called()
+        assert registers.y_index == 0
+        assert registers.negative_flag == False
+        assert registers.zero_flag
 
-        opcode = OpCode()
-        registers = Registers() 
-        dummy_value = 0x7c # (positive, not zero)
-        registers.x_index = dummy_value
+def test_execute_dey_128_to_127():
 
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0x9A, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertEqual(registers.x_index, dummy_value)
-            self.assertEqual(registers.sp, dummy_value)
-            self.assertFalse(registers.negative_flag) # default sp should be $fd
-            self.assertFalse(registers.zero_flag)
+    opcode = OpCode()
+    registers = Registers() 
+    registers.y_index = 0x80
+    
+    opcode.execute(0x88, registers, None)
+    assert registers.y_index == 0x7f
+    assert registers.negative_flag == False
+    assert registers.zero_flag == False
 
-    def test_execute_inx_0_to_1(self):
+def test_execute_dey_0_to_minus1():
 
-        opcode = OpCode()
-        registers = Registers() 
-        dummy_value = 0x0
-        registers.x_index = dummy_value
+    opcode = OpCode()
+    registers = Registers() 
+    registers.y_index = 0
 
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0xE8, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertEqual(registers.x_index, dummy_value + 1)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.zero_flag)
-
-    def test_execute_inx_127_to_128(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        dummy_value = 0x7f
-        registers.x_index = dummy_value
-        
-        opcode.execute(0xE8, registers, None)
-        self.assertEqual(registers.x_index, dummy_value + 1)
-        self.assertTrue(registers.negative_flag)
-        self.assertFalse(registers.zero_flag)
-
-    def test_execute_inx_255_to_0(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        registers.x_index = 0xff
-
-        opcode.execute(0xE8, registers, None)
-        self.assertEqual(registers.x_index, 0)
-        self.assertFalse(registers.negative_flag)
-        self.assertTrue(registers.zero_flag)
-
-    def test_execute_iny_0_to_1(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        dummy_value = 0x0
-        registers.y_index = dummy_value
-
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0xC8, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertEqual(registers.y_index, dummy_value + 1)
-            self.assertFalse(registers.negative_flag)
-            self.assertFalse(registers.zero_flag)
-
-    def test_execute_iny_127_to_128(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        dummy_value = 0x7f
-        registers.y_index = dummy_value
-        
-        opcode.execute(0xC8, registers, None)
-        self.assertEqual(registers.y_index, dummy_value + 1)
-        self.assertTrue(registers.negative_flag)
-        self.assertFalse(registers.zero_flag)
-
-    def test_execute_iny_255_to_0(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        registers.y_index = 0xff
-
-        opcode.execute(0xC8, registers, None)
-        self.assertEqual(registers.y_index, 0)
-        self.assertFalse(registers.negative_flag)
-        self.assertTrue(registers.zero_flag)
-
-    def test_execute_dex_1_to_0(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        registers.x_index = 1
-
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0xCA, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertEqual(registers.x_index, 0)
-            self.assertFalse(registers.negative_flag)
-            self.assertTrue(registers.zero_flag)
-
-    def test_execute_dex_128_to_127(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        registers.x_index = 0x80
-        
-        opcode.execute(0xCA, registers, None)
-        self.assertEqual(registers.x_index, 0x7f)
-        self.assertFalse(registers.negative_flag)
-        self.assertFalse(registers.zero_flag)
-
-    def test_execute_dex_0_to_minus1(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        registers.x_index = 0
-
-        opcode.execute(0xCA, registers, None)
-        self.assertEqual(registers.x_index, 255)
-        self.assertTrue(registers.negative_flag)
-        self.assertFalse(registers.zero_flag)
-
-    def test_execute_dey_1_to_0(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        registers.y_index = 1
-
-        with patch.object(MemoryController, 'read', return_value = None) as mock_memory_controller:
-            count = opcode.execute(0x88, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
-            mock_memory_controller.assert_not_called()
-            self.assertEqual(registers.y_index, 0)
-            self.assertFalse(registers.negative_flag)
-            self.assertTrue(registers.zero_flag)
-
-    def test_execute_dey_128_to_127(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        registers.y_index = 0x80
-        
-        opcode.execute(0x88, registers, None)
-        self.assertEqual(registers.y_index, 0x7f)
-        self.assertFalse(registers.negative_flag)
-        self.assertFalse(registers.zero_flag)
-
-    def test_execute_dey_0_to_minus1(self):
-
-        opcode = OpCode()
-        registers = Registers() 
-        registers.y_index = 0
-
-        opcode.execute(0x88, registers, None)
-        self.assertEqual(registers.y_index, 255)
-        self.assertTrue(registers.negative_flag)
-        self.assertFalse(registers.zero_flag)
-
-if __name__ == '__main__':
-    unittest.main()
+    opcode.execute(0x88, registers, None)
+    assert registers.y_index == 255
+    assert registers.negative_flag
+    assert registers.zero_flag == False

--- a/tests/test_inc_dec_opcodes.py
+++ b/tests/test_inc_dec_opcodes.py
@@ -6,196 +6,191 @@ from emupy6502.registers import Registers
 from emupy6502.opcodes import OpCode
 
 
-class OpCodeTestsIncAndDec(unittest.TestCase):
+def execute_inc_positive( actual_opcode, expected_clocks, pc_value, mock_memory_controller, **kwargs):
 
-    def execute_inc_positive(self, actual_opcode, expected_clocks, pc_value, mock_memory_controller, **kwargs):
+    opcode = OpCode()
+    registers = Registers()
 
-        opcode = OpCode()
-        registers = Registers()
+    if kwargs:
+        for arg in kwargs:
+            setattr(registers, arg, kwargs[arg])
 
-        if kwargs:
-            for arg in kwargs:
-                setattr(registers, arg, kwargs[arg])
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(actual_opcode, registers, mock_memory_controller)
+    assert count == expected_clocks
+    assert registers.pc == pc_value
+    assert registers.zero_flag == False
+    assert registers.negative_flag == False
 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(actual_opcode, registers, mock_memory_controller)
-        self.assertEqual(count, expected_clocks)
-        self.assertEqual(registers.pc, pc_value)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.negative_flag)
+def test_execute_inc_zeropage_positive():
 
-    def test_execute_inc_zeropage_positive(self):
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 6]
+    # we're mocking 0xE6 0x21 and [0x21] = 6
+    execute_inc_positive(0xE6, 5, 2, mock_memory_controller)
+    assert mock_memory_controller.read.call_count == 2
+    mock_memory_controller.write.assert_called_with(0x21, 7)
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 6]
-        # we're mocking 0xE6 0x21 and [0x21] = 6
-        self.execute_inc_positive(0xE6, 5, 2, mock_memory_controller)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        mock_memory_controller.write.assert_called_with(0x21, 7)
+def test_execute_inc_absolute_positive():
 
-    def test_execute_inc_absolute_positive(self):
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x00, 0x21, 6]
+    # we're mocking 0xEE 0x00 0x21 and [0x2100] = 6
+    execute_inc_positive(0xEE, 6, 3, mock_memory_controller)
+    assert mock_memory_controller.read.call_count == 3
+    mock_memory_controller.write.assert_called_with(0x2100, 7)
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x00, 0x21, 6]
-        # we're mocking 0xEE 0x00 0x21 and [0x2100] = 6
-        self.execute_inc_positive(0xEE, 6, 3, mock_memory_controller)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-        mock_memory_controller.write.assert_called_with(0x2100, 7)
+def test_execute_inc_zeropageX_positive():
 
-    def test_execute_inc_zeropageX_positive(self):
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 6]
+    # we're mocking 0xF6 0x21 and [0x24] = 6
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 6]
-        # we're mocking 0xF6 0x21 and [0x24] = 6
+    execute_inc_positive(0xF6, 6, 2, mock_memory_controller, x_index = 3)
+    assert mock_memory_controller.read.call_count == 2
+    mock_memory_controller.write.assert_called_with(0x24, 7)
 
-        self.execute_inc_positive(0xF6, 6, 2, mock_memory_controller, x_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        mock_memory_controller.write.assert_called_with(0x24, 7)
+def test_execute_inc_absoluteX_positive():
 
-    def test_execute_inc_absoluteX_positive(self):
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0, 0x20, 6]
+    # we're mocking 0xFE 0x00 0x20 and [0x2003] = 6
+    execute_inc_positive(0xFE, 7, 3, mock_memory_controller, x_index = 3)
+    assert mock_memory_controller.read.call_count == 3
+    mock_memory_controller.write.assert_called_with(0x2003, 7)
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0, 0x20, 6]
-        # we're mocking 0xFE 0x00 0x20 and [0x2003] = 6
-        self.execute_inc_positive(0xFE, 7, 3, mock_memory_controller, x_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-        mock_memory_controller.write.assert_called_with(0x2003, 7)
+def test_execute_inc_zeropage_negative():
 
-    def test_execute_inc_zeropage_negative(self):
+    opcode = OpCode()
+    registers = Registers()
 
-        opcode = OpCode()
-        registers = Registers()
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 0xfe]
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 0xfe]
+    # we're mocking 0xE6 0x21 and [0x21] = 0xfe
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xE6, registers, mock_memory_controller)
+    assert count == 5
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    mock_memory_controller.write.assert_called_with(0x21, 0xff)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.negative_flag
 
-        # we're mocking 0xE6 0x21 and [0x21] = 0xfe
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xE6, registers, mock_memory_controller)
-        self.assertEqual(count, 5)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        mock_memory_controller.write.assert_called_with(0x21, 0xff)
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.negative_flag)
+def test_execute_inc_zeropage_zero():
 
-    def test_execute_inc_zeropage_zero(self):
+    opcode = OpCode()
+    registers = Registers()
 
-        opcode = OpCode()
-        registers = Registers()
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 0xff]
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 0xff]
+    # we're mocking 0xE6 0x21 and [0x21] = 0xff
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xE6, registers, mock_memory_controller)
+    assert count == 5
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    mock_memory_controller.write.assert_called_with(0x21, 0)
+    assert registers.pc == 2
+    assert registers.zero_flag
+    assert registers.negative_flag == False
 
-        # we're mocking 0xE6 0x21 and [0x21] = 0xff
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xE6, registers, mock_memory_controller)
-        self.assertEqual(count, 5)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        mock_memory_controller.write.assert_called_with(0x21, 0)
-        self.assertEqual(registers.pc, 2)
-        self.assertTrue(registers.zero_flag)
-        self.assertFalse(registers.negative_flag)
+def execute_dec_positive( actual_opcode, expected_clocks, mock_memory_controller, **kwargs):
 
-    def execute_dec_positive(self, actual_opcode, expected_clocks, mock_memory_controller, **kwargs):
+    opcode = OpCode()
+    registers = Registers()
 
-        opcode = OpCode()
-        registers = Registers()
+    if kwargs:
+        for arg in kwargs:
+            setattr(registers, arg, kwargs[arg])
 
-        if kwargs:
-            for arg in kwargs:
-                setattr(registers, arg, kwargs[arg])
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(actual_opcode, registers, mock_memory_controller)
+    assert count == expected_clocks
+    assert registers.pc == mock_memory_controller.read.call_count
+    assert registers.zero_flag == False
+    assert registers.negative_flag == False
 
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(actual_opcode, registers, mock_memory_controller)
-        self.assertEqual(count, expected_clocks)
-        self.assertEqual(registers.pc, mock_memory_controller.read.call_count)
-        self.assertFalse(registers.zero_flag)
-        self.assertFalse(registers.negative_flag)
+def test_execute_dec_zeropage_positive():
 
-    def test_execute_dec_zeropage_positive(self):
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 6]
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 6]
+    # we're mocking 0xC6 0x21 and [0x21] = 6
+    execute_dec_positive(0xC6, 5, mock_memory_controller)
+    assert mock_memory_controller.read.call_count == 2
+    mock_memory_controller.write.assert_called_with(0x21, 5)
 
-        # we're mocking 0xC6 0x21 and [0x21] = 6
-        self.execute_dec_positive(0xC6, 5, mock_memory_controller)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        mock_memory_controller.write.assert_called_with(0x21, 5)
+def test_execute_dec_zeropageX_positive():
 
-    def test_execute_dec_zeropageX_positive(self):
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 6]
+    # we're mocking 0xD6 0x21 and [0x24] = 6
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 6]
-        # we're mocking 0xD6 0x21 and [0x24] = 6
+    execute_dec_positive(0xD6, 6, mock_memory_controller, x_index = 3)
+    assert mock_memory_controller.read.call_count == 2
+    mock_memory_controller.write.assert_called_with(0x24, 5)
 
-        self.execute_dec_positive(0xD6, 6, mock_memory_controller, x_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        mock_memory_controller.write.assert_called_with(0x24, 5)
+def test_execute_dec_absolute_positive():
 
-    def test_execute_dec_absolute_positive(self):
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x00, 0x21, 6]
+    # we're mocking 0xCE 0x00, 0x21 and [0x2100] = 6
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x00, 0x21, 6]
-        # we're mocking 0xCE 0x00, 0x21 and [0x2100] = 6
+    execute_dec_positive(0xCE, 6, mock_memory_controller)
+    assert mock_memory_controller.read.call_count == 3
+    mock_memory_controller.write.assert_called_with(0x2100, 5)
 
-        self.execute_dec_positive(0xCE, 6, mock_memory_controller)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-        mock_memory_controller.write.assert_called_with(0x2100, 5)
+def test_execute_dec_absoluteX_positive():
 
-    def test_execute_dec_absoluteX_positive(self):
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x00, 0x21, 6]
+    # we're mocking 0xDE 0x00, 0x21 and [0x2103] = 6
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x00, 0x21, 6]
-        # we're mocking 0xDE 0x00, 0x21 and [0x2103] = 6
+    execute_dec_positive(0xDE, 7, mock_memory_controller, x_index = 3)
+    assert mock_memory_controller.read.call_count == 3
+    mock_memory_controller.write.assert_called_with(0x2103, 5)
 
-        self.execute_dec_positive(0xDE, 7, mock_memory_controller, x_index = 3)
-        self.assertEqual(mock_memory_controller.read.call_count, 3)
-        mock_memory_controller.write.assert_called_with(0x2103, 5)
+def test_execute_dec_zeropage_negative():
 
-    def test_execute_dec_zeropage_negative(self):
+    opcode = OpCode()
+    registers = Registers()
 
-        opcode = OpCode()
-        registers = Registers()
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 0xfe]
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 0xfe]
+    # we're mocking 0xC6 0x21 and [0x21] = 0xfe
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC6, registers, mock_memory_controller)
+    assert count == 5
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    mock_memory_controller.write.assert_called_with(0x21, 0xfd)
+    assert registers.pc == 2
+    assert registers.zero_flag == False
+    assert registers.negative_flag
 
-        # we're mocking 0xC6 0x21 and [0x21] = 0xfe
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC6, registers, mock_memory_controller)
-        self.assertEqual(count, 5)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        mock_memory_controller.write.assert_called_with(0x21, 0xfd)
-        self.assertEqual(registers.pc, 2)
-        self.assertFalse(registers.zero_flag)
-        self.assertTrue(registers.negative_flag)
+def test_execute_dec_zeropage_zero():
 
-    def test_execute_dec_zeropage_zero(self):
+    opcode = OpCode()
+    registers = Registers()
 
-        opcode = OpCode()
-        registers = Registers()
+    mock_memory_controller = Mock()
+    mock_memory_controller.read.side_effect = [0x21, 1]
 
-        mock_memory_controller = Mock()
-        mock_memory_controller.read.side_effect = [0x21, 1]
-
-        # we're mocking 0xC6 0x21 and [0x21] = 1
-        registers.pc += 1 #need to fake the cpu reading the opcode
-        count = opcode.execute(0xC6, registers, mock_memory_controller)
-        self.assertEqual(count, 5)
-        self.assertEqual(mock_memory_controller.read.call_count, 2)
-        self.assertEqual(mock_memory_controller.read.call_args_list[0], unittest.mock.call(1))
-        self.assertEqual(mock_memory_controller.read.call_args_list[1], unittest.mock.call(0x21))
-        mock_memory_controller.write.assert_called_with(0x21, 0)
-        self.assertEqual(registers.pc, 2)
-        self.assertTrue(registers.zero_flag)
-        self.assertFalse(registers.negative_flag)
-
-if __name__ == '__main__':
-    unittest.main()
+    # we're mocking 0xC6 0x21 and [0x21] = 1
+    registers.pc += 1 #need to fake the cpu reading the opcode
+    count = opcode.execute(0xC6, registers, mock_memory_controller)
+    assert count == 5
+    assert mock_memory_controller.read.call_count == 2
+    assert mock_memory_controller.read.call_args_list[0] == unittest.mock.call(1)
+    assert mock_memory_controller.read.call_args_list[1] == unittest.mock.call(0x21)
+    mock_memory_controller.write.assert_called_with(0x21, 0)
+    assert registers.pc == 2
+    assert registers.zero_flag
+    assert registers.negative_flag == False

--- a/tests/test_jump_branch_opcodes.py
+++ b/tests/test_jump_branch_opcodes.py
@@ -6,345 +6,340 @@ from emupy6502.registers import Registers
 from emupy6502.opcodes import OpCode
 
 
-class OpCodeTestsJumpsAndBranches(unittest.TestCase):
+def test_execute_jmp_absolute():
 
-    def test_execute_jmp_absolute(self):
+    opcode = OpCode()
+    registers = Registers()
 
-        opcode = OpCode()
-        registers = Registers()
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x00, 0xc0]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x4C, registers, mock_memory_controller)
+        assert count == 3
 
-            mock_memory_controller.read.side_effect = [0x00, 0xc0]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x4C, registers, mock_memory_controller)
-            self.assertEqual(count, 3)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 2
+        assert registers.pc == 0xc000
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 2)
-            self.assertEqual(registers.pc, 0xc000)
+def test_execute_jmp_indirect():
 
-    def test_execute_jmp_indirect(self):
+    opcode = OpCode()
+    registers = Registers()
 
-        opcode = OpCode()
-        registers = Registers()
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x00, 0xc0, 0x34, 0x12]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x6C, registers, mock_memory_controller)
+        assert count == 5
 
-            mock_memory_controller.read.side_effect = [0x00, 0xc0, 0x34, 0x12]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x6C, registers, mock_memory_controller)
-            self.assertEqual(count, 5)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 4
+        assert registers.pc == 0x1234
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 4)
-            self.assertEqual(registers.pc, 0x1234)
+def test_execute_bpl_branch_not_taken():
 
-    def test_execute_bpl_branch_not_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.negative_flag = True
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.negative_flag = True
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x02]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x10, registers, mock_memory_controller)
+        assert count == 2
 
-            mock_memory_controller.read.side_effect = [0x02]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x10, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc002
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc002)
+def test_execute_bpl_branch_taken_forward_no_page_boundary():
 
-    def test_execute_bpl_branch_taken_forward_no_page_boundary(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.negative_flag = False
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.negative_flag = False
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x03]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x10, registers, mock_memory_controller)
+        assert count == 3
 
-            mock_memory_controller.read.side_effect = [0x03]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x10, registers, mock_memory_controller)
-            self.assertEqual(count, 3)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc005
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc005)
+def test_execute_bpl_branch_taken_backward_no_page_boundary():
 
-    def test_execute_bpl_branch_taken_backward_no_page_boundary(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.negative_flag = False
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.negative_flag = False
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0xfe]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x10, registers, mock_memory_controller)
+        assert count == 3
 
-            mock_memory_controller.read.side_effect = [0xfe]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x10, registers, mock_memory_controller)
-            self.assertEqual(count, 3)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc000
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc000)
+def test_execute_bmi_branch_not_taken():
 
-    def test_execute_bmi_branch_not_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.negative_flag = False
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.negative_flag = False
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x02]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x30, registers, mock_memory_controller)
+        assert count == 2
 
-            mock_memory_controller.read.side_effect = [0x02]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x30, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc002
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc002)
+def test_execute_bmi_branch_taken():
 
-    def test_execute_bmi_branch_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.negative_flag = True
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.negative_flag = True
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0xfe]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x30, registers, mock_memory_controller)
+        assert count == 3
 
-            mock_memory_controller.read.side_effect = [0xfe]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x30, registers, mock_memory_controller)
-            self.assertEqual(count, 3)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc000
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc000)
+def test_execute_bvc_branch_not_taken():
 
-    def test_execute_bvc_branch_not_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.overflow_flag = True
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.overflow_flag = True
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x02]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x50, registers, mock_memory_controller)
+        assert count == 2
 
-            mock_memory_controller.read.side_effect = [0x02]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x50, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc002
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc002)
+def test_execute_bvc_branch_taken():
 
-    def test_execute_bvc_branch_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.overflow_flag = False
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.overflow_flag = False
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0xfe]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x50, registers, mock_memory_controller)
+        assert count == 3
 
-            mock_memory_controller.read.side_effect = [0xfe]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x50, registers, mock_memory_controller)
-            self.assertEqual(count, 3)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc000
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc000)
+def test_execute_bvs_branch_not_taken():
 
-    def test_execute_bvs_branch_not_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.overflow_flag = False
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.overflow_flag = False
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x02]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x70, registers, mock_memory_controller)
+        assert count == 2
 
-            mock_memory_controller.read.side_effect = [0x02]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x70, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc002
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc002)
+def test_execute_bvs_branch_taken():
 
-    def test_execute_bvs_branch_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.overflow_flag = True
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.overflow_flag = True
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0xfe]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x70, registers, mock_memory_controller)
+        assert count == 3
 
-            mock_memory_controller.read.side_effect = [0xfe]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x70, registers, mock_memory_controller)
-            self.assertEqual(count, 3)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc000
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc000)
+def test_execute_bcc_branch_not_taken():
 
-    def test_execute_bcc_branch_not_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.carry_flag = True
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.carry_flag = True
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x02]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x90, registers, mock_memory_controller)
+        assert count == 2
 
-            mock_memory_controller.read.side_effect = [0x02]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x90, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc002
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc002)
+def test_execute_bcc_branch_taken():
 
-    def test_execute_bcc_branch_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.carry_flag = False
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.carry_flag = False
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0xfe]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0x90, registers, mock_memory_controller)
+        assert count == 3
 
-            mock_memory_controller.read.side_effect = [0xfe]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0x90, registers, mock_memory_controller)
-            self.assertEqual(count, 3)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc000
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc000)
+def test_execute_bcs_branch_not_taken():
 
-    def test_execute_bcs_branch_not_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.carry_flag = False
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.carry_flag = False
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x02]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xb0, registers, mock_memory_controller)
+        assert count == 2
 
-            mock_memory_controller.read.side_effect = [0x02]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xb0, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc002
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc002)
+def test_execute_bcs_branch_taken():
 
-    def test_execute_bcs_branch_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.carry_flag = True
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.carry_flag = True
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0xfe]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xb0, registers, mock_memory_controller)
+        assert count == 3
 
-            mock_memory_controller.read.side_effect = [0xfe]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xb0, registers, mock_memory_controller)
-            self.assertEqual(count, 3)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc000
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc000)
+def test_execute_bne_branch_not_taken():
 
-    def test_execute_bne_branch_not_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.zero_flag = True
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.zero_flag = True
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x02]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xd0, registers, mock_memory_controller)
+        assert count == 2
 
-            mock_memory_controller.read.side_effect = [0x02]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xd0, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc002
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc002)
+def test_execute_bne_branch_taken():
 
-    def test_execute_bne_branch_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.zero_flag = False
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.zero_flag = False
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0xfe]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xd0, registers, mock_memory_controller)
+        assert count == 3
 
-            mock_memory_controller.read.side_effect = [0xfe]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xd0, registers, mock_memory_controller)
-            self.assertEqual(count, 3)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc000
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc000)
+def test_execute_beq_branch_not_taken():
 
-    def test_execute_beq_branch_not_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.zero_flag = False
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.zero_flag = False
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0x02]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xf0, registers, mock_memory_controller)
+        assert count == 2
 
-            mock_memory_controller.read.side_effect = [0x02]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xf0, registers, mock_memory_controller)
-            self.assertEqual(count, 2)
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc002
 
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc002)
+def test_execute_beq_branch_taken():
 
-    def test_execute_beq_branch_taken(self):
+    opcode = OpCode()
+    registers = Registers()
+    registers.zero_flag = True
+    registers.pc = 0xc000
 
-        opcode = OpCode()
-        registers = Registers()
-        registers.zero_flag = True
-        registers.pc = 0xc000
+    with patch.object(MemoryController, 'read') as mock_memory_controller:
 
-        with patch.object(MemoryController, 'read') as mock_memory_controller:
+        mock_memory_controller.read.side_effect = [0xfe]
+        registers.pc += 1 #need to fake the cpu reading the opcode
+        count = opcode.execute(0xf0, registers, mock_memory_controller)
+        assert count == 3
 
-            mock_memory_controller.read.side_effect = [0xfe]
-            registers.pc += 1 #need to fake the cpu reading the opcode
-            count = opcode.execute(0xf0, registers, mock_memory_controller)
-            self.assertEqual(count, 3)
-
-            # Tested more thoroughly in addressing_modes_tests
-            self.assertEqual(mock_memory_controller.read.call_count, 1)
-            self.assertEqual(registers.pc, 0xc000)
-
-if __name__ == '__main__':
-    unittest.main()
+        # Tested more thoroughly in addressing_modes_tests
+        assert mock_memory_controller.read.call_count == 1
+        assert registers.pc == 0xc000


### PR DESCRIPTION
First pr containing changes to swtich from unittest -> pytest.

Splitting PRs since it contains a lot of updated lines. This pr gets rid of the remaining asserts, more to come to remove mocks.